### PR TITLE
Gmmq 148 feat: 공통 button 컴포넌트 개발

### DIFF
--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,17 +1,17 @@
-import { Button as ChakraButton } from '@chakra-ui/react';
+import { Button as ChakraButton, ButtonProps as ChakraButtonProps } from '@chakra-ui/react';
 
-type ButtonProps = {
+type ButtonProps = ChakraButtonProps & {
   variant?: 'default' | 'cancel';
   size?: 'lg' | 'md' | 'sm' | 'xs' | 'full';
-
   children: string;
 };
 
-const Button = ({ size = 'full', variant = 'default', children }: ButtonProps) => {
+const Button = ({ size = 'full', variant = 'default', children, ...props }: ButtonProps) => {
   return (
     <ChakraButton
       variant={variant}
       size={size}
+      {...props}
     >
       {children}
     </ChakraButton>

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -1,0 +1,21 @@
+import { Button as ChakraButton } from '@chakra-ui/react';
+
+type ButtonProps = {
+  variant?: 'default' | 'cancel';
+  size?: 'lg' | 'md' | 'sm' | 'xs' | 'full';
+
+  children: string;
+};
+
+const Button = ({ size = 'full', variant = 'default', children }: ButtonProps) => {
+  return (
+    <ChakraButton
+      variant={variant}
+      size={size}
+    >
+      {children}
+    </ChakraButton>
+  );
+};
+
+export default Button;

--- a/src/components/atoms/Button/index.stories.tsx
+++ b/src/components/atoms/Button/index.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Button } from '.';
+
+const meta = {
+  title: 'Resumeme/Components/Button',
+  component: Button,
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      options: ['default', 'cancel'],
+      control: { type: 'radio' },
+    },
+    size: {
+      options: ['lg', 'md', 'sm', 'xs', 'full'],
+      control: { type: 'radio' },
+    },
+    children: {
+      control: 'text',
+    },
+  },
+} satisfies Meta<typeof Button>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const DefaultButton: Story = {
+  args: {
+    variant: 'default',
+    size: 'lg',
+    children: 'Button',
+  },
+};
+
+export const CancelButton: Story = {
+  args: {
+    variant: 'cancel',
+    size: 'lg',
+    children: 'Button',
+  },
+};

--- a/src/components/atoms/Button/index.ts
+++ b/src/components/atoms/Button/index.ts
@@ -1,0 +1,1 @@
+export { default as Button } from './Button';

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,0 +1,47 @@
+import { defineStyleConfig } from '@chakra-ui/react';
+
+const Button = defineStyleConfig({
+  baseStyle: {
+    borderRadius: '0.625rem',
+  },
+  sizes: {
+    lg: {
+      w: '25.25rem',
+      h: '2.69rem',
+      fontSize: '1rem',
+    },
+    md: {
+      w: '10rem',
+      h: '2.69rem',
+      fontSize: '1rem',
+    },
+    sm: {
+      w: '5.125rem',
+      h: '2.69rem',
+      fontSize: '1rem',
+    },
+    xs: {
+      w: '3.16rem',
+      h: '2rem',
+      fontSize: '0.875rem',
+    },
+    full: {
+      w: '100%',
+      h: '2.69rem',
+    },
+  },
+  variants: {
+    cancel: {
+      border: '1px solid',
+      borderColor: 'gray.300',
+      color: 'gray.400',
+      bg: 'gray.100',
+    },
+    default: {
+      color: 'gray.100',
+      bg: 'primary.900',
+    },
+  },
+  defaultProps: {},
+});
+export { Button };

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,3 +1,4 @@
-import { Input } from '~/theme/components/input';
+import { Button } from './button';
+import { Input } from './input';
 
-export { Input };
+export { Input, Button };

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 import { StyleFunctionProps, extendTheme } from '@chakra-ui/react';
-import { Input } from '~/theme/components';
+import { Input, Button } from '~/theme/components';
 
 const theme = extendTheme({
   breakpoints: {
@@ -79,7 +79,7 @@ const theme = extendTheme({
     '8xl': '6rem',
     '9xl': '8rem',
   },
-  components: { Input },
+  components: { Input, Button },
 });
 
 export default theme;


### PR DESCRIPTION
**기존 GMMQ-148-feat/Button 브랜치는 rebase과정에서 뭐가 꼬였는지 충돌이 무한정 나서 그냥 브랜치 새로 만들고 복붙해왔습니다..** 

## 💻 스크린샷 (선택사항)

<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
⬇️ variant='default', size='full'
<img width="1049" alt="스크린샷 2023-10-29 오전 2 17 02" src="https://github.com/resumeme/Frontend/assets/91667853/0f15fe0b-2cc9-40d9-b8fc-18a25f6cb316">
⬇️ variant='cancel', size='md'
<img width="1037" alt="스크린샷 2023-10-29 오전 2 17 57" src="https://github.com/resumeme/Frontend/assets/91667853/5e0486e4-1271-41d1-a808-df414c6ad986">

## 📃 PR 설명

<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->

- 공통 버튼 컴포넌트를 만들었습니다.
- button용 theme을 따로 작성해서 스타일링을 했습니다.
  - 공통으로 쓰이는 버튼들은 아예 theme에서 variant로 커스텀해둬도 좋을 것 같아 theme에 작성했습니다.
  - theme을 만들다보니 src/components 에 컴포넌트를 굳이 또 새로 만들어야 하나 고민이 됐는데, 사용하는 입장에서는 필요한 props가 따로 정의된 컴포넌트를 불러와서 사용하는 게 더 편할 것 같다 생각했습니다. (차크라 컴포넌트를 바로 가져와서 쓰는 건 자유도가 너무 높아서)

### props 정리

- `size` props
  - `full`: 부모 컴포넌트의 width를 100% 채우게 할 때 (이벤트 리스트 페이지, 이벤트 상세 페이지 등등)
  - `md`: 개인정보 수정 페이지, 후기 작성 페이지, 이벤트 생성 페이지
  - `sm`: 이력서 작성 페이지의 각 블럭
  - `xs`: 이력서 작성 페이지의 제목, 참고링크 부분

- `variant` props
  - `default`: 저장, 다음 등의 초록 배경 버튼
  - `cancel`: 취소 버튼

### 사용법 예시

ex) 부모 컴포넌트의 width를 가득 채우게 할 때

```typescript
import { Button } from '~/components/atoms/Button';

const Component = () => {
  return (
      <Box
        w={20}
      >
        <Button
          variant="cancel"
          size="full"
        >
          취소버튼
        </Button>
      </Box>
  );
};
```

## 📃 참고사항

<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

- 아까 컴포넌트에서 받는 variant는 기존 차크라 컴포넌트의 variant와 헷갈리니 type으로 통일하자 얘기를 했었는데, 개발하다 보니 저는 오히려 이름이 다르면 헷갈리게 되는 것 같더라구요.. 그래서 같은 이름 variant로 통일했습니다! @khakhiD
- 스토리북에서 chakra theme이 작동하지 않았던 이유는.. `./storybook/preview.ts`에서 불러오던 theme이 저희가 작성한 theme이 아니라 차크라 기본 theme을 불러오고 있었기 때문입니다...^^

## 🔎 PR포인트 및 궁금한 점
