### PR TITLE
Gmmq 78 feat: Header UI와 전체 레이아웃 구현

### DIFF
--- a/src/components/organisms/Footer/Footer.tsx
+++ b/src/components/organisms/Footer/Footer.tsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom';
 
 const FOOTER_CONTENT = {
   main: {
-    title: 'resumeme',
+    title: 'resume.me',
   },
   links: {
     almondPepero: {

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -3,7 +3,14 @@ import { Container } from '@chakra-ui/react';
 const Header = () => {
   return (
     <>
-      <Container>헤더</Container>
+      <Container
+        className="header"
+        bg="white"
+        w="full"
+        h="65px"
+      >
+        헤더
+      </Container>
     </>
   );
 };

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,5 +1,6 @@
 import { BellIcon } from '@chakra-ui/icons';
 import { Box, Flex, Button, Stack, Heading } from '@chakra-ui/react';
+import { Link } from 'react-router-dom';
 
 type NavItem = {
   label: string;
@@ -16,11 +17,11 @@ const TEXT_CONTENTS = {
 const NAV_ITEMS: Array<NavItem> = [
   {
     label: '이력서',
-    href: '#',
+    href: '/mypage/mentee',
   },
   {
     label: '피드백',
-    href: '#',
+    href: '/event/view',
   },
   {
     label: '커뮤니티',
@@ -84,23 +85,25 @@ const Header = () => {
           flex={1}
           justify={'start'}
         >
-          {/* NOTE LOGO */}
-          <Flex align="center">
-            <Box
-              bg="gray.800"
-              w="24px"
-              h="24px"
-              borderRadius="md"
-              mr="12px"
-            />
-            <Heading
-              fontSize={'xl'}
-              fontWeight={'black'}
-              color={'gray.800'}
-            >
-              {TEXT_CONTENTS.LOGO}
-            </Heading>
-          </Flex>
+          <Link to="/">
+            {/* NOTE LOGO */}
+            <Flex align="center">
+              <Box
+                bg="gray.800"
+                w="24px"
+                h="24px"
+                borderRadius="md"
+                mr="12px"
+              />
+              <Heading
+                fontSize={'xl'}
+                fontWeight={'black'}
+                color={'gray.800'}
+              >
+                {TEXT_CONTENTS.LOGO}
+              </Heading>
+            </Flex>
+          </Link>
           <Flex
             display="flex"
             ml={10}

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,0 +1,11 @@
+import { Container } from '@chakra-ui/react';
+
+const Header = () => {
+  return (
+    <>
+      <Container>헤더</Container>
+    </>
+  );
+};
+
+export default Header;

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,17 +1,151 @@
-import { Container } from '@chakra-ui/react';
+import { BellIcon } from '@chakra-ui/icons';
+import { Box, Flex, Button, Stack, Heading } from '@chakra-ui/react';
+
+type NavItem = {
+  label: string;
+  subLabel?: string;
+  children?: Array<NavItem>;
+  href?: string;
+};
+
+const TEXT_CONTENTS = {
+  LOGO: 'resume.me',
+  SIGN: '회원가입 / 로그인',
+};
+
+const NAV_ITEMS: Array<NavItem> = [
+  {
+    label: '이력서',
+    href: '#',
+  },
+  {
+    label: '피드백',
+    href: '#',
+  },
+  {
+    label: '커뮤니티',
+    href: '#',
+  },
+];
+
+const Navigation = () => {
+  const linkColor = 'gray.800';
+  const linkHoverColor = 'gray.600';
+
+  return (
+    <Stack
+      direction={'row'}
+      spacing={'70px'}
+    >
+      {NAV_ITEMS.map((navItem) => (
+        <Box key={navItem.label}>
+          <Box
+            as="a"
+            p={2}
+            href={navItem.href ?? '#'}
+            fontSize={'sm'}
+            fontWeight={600}
+            color={linkColor}
+            _hover={{
+              color: linkHoverColor,
+            }}
+          >
+            {navItem.label}
+          </Box>
+        </Box>
+      ))}
+    </Stack>
+  );
+};
 
 const Header = () => {
   return (
-    <>
-      <Container
-        className="header"
-        bg="white"
-        w="full"
-        h="65px"
+    <Box
+      className="box"
+      bg="white"
+      borderBottom={1}
+      borderStyle={'solid'}
+      borderColor="gray.300"
+      display="flex"
+      justifyContent="center"
+    >
+      <Flex
+        className="flex"
+        bg={'white'}
+        color={'gray.700'}
+        minH={'65px'}
+        w={'992px'}
+        maxW={'992px'}
+        px="12px"
+        justify={'center'}
+        align={'center'}
       >
-        헤더
-      </Container>
-    </>
+        <Flex
+          flex={1}
+          justify={'start'}
+        >
+          {/* NOTE LOGO */}
+          <Flex align="center">
+            <Box
+              bg="gray.800"
+              w="24px"
+              h="24px"
+              borderRadius="md"
+              mr="12px"
+            />
+            <Heading
+              fontSize={'xl'}
+              fontWeight={'black'}
+              color={'gray.800'}
+            >
+              {TEXT_CONTENTS.LOGO}
+            </Heading>
+          </Flex>
+          <Flex
+            display="flex"
+            ml={10}
+          >
+            <Navigation />
+          </Flex>
+        </Flex>
+
+        {/* NOTE LOGIN, NOTIFICATION */}
+        <Stack
+          direction={'row'}
+          spacing={2}
+        >
+          <Button
+            w={'144px'}
+            h={'40px'}
+            fontSize={'sm'}
+            fontWeight={600}
+            color={'primary.900'}
+            bg={'transparent'}
+            border={'1px'}
+            borderColor={'gray.300'}
+            _hover={{
+              bg: 'gray.200',
+            }}
+          >
+            {TEXT_CONTENTS.SIGN}
+          </Button>
+          <Button
+            w={'30px'}
+            h={'40px'}
+            fontSize={'sm'}
+            fontWeight={600}
+            bg={'transparent'}
+            color="gray.800"
+            _hover={{
+              bg: 'gray.200',
+              color: 'primary.900',
+            }}
+          >
+            <BellIcon fontSize={'1.2rem'} />
+          </Button>
+        </Stack>
+      </Flex>
+    </Box>
   );
 };
 

--- a/src/components/organisms/Header/index.ts
+++ b/src/components/organisms/Header/index.ts
@@ -1,0 +1,1 @@
+export { default as Header } from './Header';

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -5,42 +5,40 @@ import { Header } from '~/components/organisms/Header';
 
 const Layout = () => {
   return (
-    <>
+    <Box
+      minH={'100vh'}
+      display={'flex'}
+      flexDirection={'column'}
+    >
       <Box
-        minH={'100vh'}
-        display={'flex'}
-        flexDirection={'column'}
+        position={'fixed'}
+        w={'full'}
+        top={0}
+        left={'50%'}
+        transform="translate(-50%, 0)"
+        flexGrow={0}
+        flexShrink={0}
       >
-        <Box
-          position={'fixed'}
-          w={'full'}
-          top={0}
-          left={'50%'}
-          transform="translate(-50%, 0)"
-          flexGrow={0}
-          flexShrink={0}
-        >
-          <Header />
-        </Box>
-        <Box
-          flexGrow={1}
-          mt={'66px'}
-          w={'100%'}
-          maxW={'992px'}
-          mx={'auto'}
-          py={'3rem'}
-          px={'12px'}
-        >
-          <Outlet />
-        </Box>
-        <Box
-          flexGrow={0}
-          flexShrink={0}
-        >
-          <Footer />
-        </Box>
+        <Header />
       </Box>
-    </>
+      <Box
+        flexGrow={1}
+        mt={'66px'}
+        w={'100%'}
+        maxW={'992px'}
+        mx={'auto'}
+        py={'3rem'}
+        px={'12px'}
+      >
+        <Outlet />
+      </Box>
+      <Box
+        flexGrow={0}
+        flexShrink={0}
+      >
+        <Footer />
+      </Box>
+    </Box>
   );
 };
 

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,11 +1,45 @@
-import { Heading } from '@chakra-ui/react';
+import { Box } from '@chakra-ui/react';
 import { Outlet } from 'react-router-dom';
+import Footer from '~/components/organisms/Footer/Footer';
+import { Header } from '~/components/organisms/Header';
 
 const Layout = () => {
   return (
     <>
-      <Heading>예를 들어 Header가 들어갈 공간, Outlet에는 경로가 "/"일 때 null 값이 들어감</Heading>
-      <Outlet />
+      <Box
+        minH={'100vh'}
+        display={'flex'}
+        flexDirection={'column'}
+      >
+        <Box
+          position={'fixed'}
+          w={'full'}
+          top={0}
+          left={'50%'}
+          transform="translate(-50%, 0)"
+          flexGrow={0}
+          flexShrink={0}
+        >
+          <Header />
+        </Box>
+        <Box
+          flexGrow={1}
+          mt={'66px'}
+          w={'100%'}
+          maxW={'992px'}
+          mx={'auto'}
+          py={'3rem'}
+          px={'12px'}
+        >
+          <Outlet />
+        </Box>
+        <Box
+          flexGrow={0}
+          flexShrink={0}
+        >
+          <Footer />
+        </Box>
+      </Box>
     </>
   );
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/5e69bdc5-1174-4a1d-9284-60678c183bcc)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- **`Header`** UI 컴포넌트를 개발했습니다. (사용자에 따른 화면 변화나 기능은 포함되지 않음)
- 전체 레이아웃을 **`Layout.tsx`** 에 구현했습니다.
- **`Footer`** 컴포넌트 내부에 간단한 오타를 수정했습니다.
  - resumeme -> resume.me

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
