### PR TITLE
Gmmq 167 feat: 로그인/회원가입 레이아웃

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,13 @@
+import { useLocation } from 'react-router-dom';
+import FocusLayout from './routes/FocusLayout';
 import Layout from '~/routes/Layout';
 
 const App = () => {
+  const regex = /^\/sign-/;
+  const currentPage = useLocation().pathname;
+  if (regex.test(currentPage)) {
+    return <FocusLayout />;
+  }
   return <Layout />;
 };
 

--- a/src/routes/FocusLayout.tsx
+++ b/src/routes/FocusLayout.tsx
@@ -5,17 +5,10 @@ const FocusLayout = () => {
   return (
     <Flex
       minH={'100vh'}
-      direction={'column'}
+      justifyContent={'center'}
+      alignItems={'center'}
     >
-      <Box
-        flexGrow={1}
-        mt={'66px'}
-        w={'100%'}
-        maxW={'992px'}
-        mx={'auto'}
-        py={'3rem'}
-        px={'12px'}
-      >
+      <Box maxW={'992px'}>
         <Outlet />
       </Box>
     </Flex>

--- a/src/routes/FocusLayout.tsx
+++ b/src/routes/FocusLayout.tsx
@@ -1,0 +1,25 @@
+import { Box, Flex } from '@chakra-ui/react';
+import { Outlet } from 'react-router-dom';
+
+const FocusLayout = () => {
+  return (
+    <Flex
+      minH={'100vh'}
+      direction={'column'}
+    >
+      <Box
+        flexGrow={1}
+        mt={'66px'}
+        w={'100%'}
+        maxW={'992px'}
+        mx={'auto'}
+        py={'3rem'}
+        px={'12px'}
+      >
+        <Outlet />
+      </Box>
+    </Flex>
+  );
+};
+
+export default FocusLayout;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="1440" alt="스크린샷 2023-11-02 오후 1 38 51" src="https://github.com/resumeme/Frontend/assets/91667853/bdf3941f-2a46-4503-ac11-5ba146a786b4">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 로그인, 회원가입 페이지의 레이아웃을 추가했습니다.
- App.tsx에서 /sign-으로 시작하는 정규표현식으로 페이지를 구분해서 FocusLayout이 적용되도록 했습니다. 기존 Route 방식으로는 멘토님 말씀하신 방식으로 해줄 수 있을 것 같은데, createBrowserRouter를 사용해서는 어떻게 구분할 수 있을지 좀 더 찾아봐야 할 것 같네요.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
