### PR TITLE
Gmmq 168 feat: 이력서 작성 페이지 - 기본 프로필 입력 부분 UI 및 사소한 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.47.0",
+        "react-icons": "^4.11.0",
         "react-router-dom": "^6.17.0",
         "zustand": "^4.4.3"
       },
@@ -14342,6 +14343,14 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-inspector": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.47.0",
+    "react-icons": "^4.11.0",
     "react-router-dom": "^6.17.0",
     "zustand": "^4.4.3"
   },

--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -1,0 +1,26 @@
+import { Input, InputProps } from '@chakra-ui/react';
+
+type TitleInputProps = InputProps;
+
+const TitleInput = ({ children, ...props }: TitleInputProps) => {
+  return (
+    <Input
+      width={'100%'}
+      height={'60px'}
+      border={'none'}
+      color={'gray.800'}
+      borderBottom={'1px'}
+      borderRadius={'none'}
+      borderColor={'gray.300'}
+      placeholder="이력서 제목"
+      _placeholder={{ color: 'gray.400', fontWeight: 'light' }}
+      fontSize={'32px'}
+      px={2}
+      {...props}
+    >
+      {children}
+    </Input>
+  );
+};
+
+export default TitleInput;

--- a/src/components/atoms/TitleInput/index.stories.ts
+++ b/src/components/atoms/TitleInput/index.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import TitleInput from './TitleInput';
+
+const meta = {
+  title: 'Resumeme/Components/TitleInput',
+  component: TitleInput,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof TitleInput>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/src/components/organisms/ResumeBasicInput/LinkIconBox.tsx
+++ b/src/components/organisms/ResumeBasicInput/LinkIconBox.tsx
@@ -1,0 +1,62 @@
+import { LinkIcon } from '@chakra-ui/icons';
+import { Box, Text, Link, Flex, Icon } from '@chakra-ui/react';
+import { DiGithubAlt } from 'react-icons/di';
+
+type LinkIconBoxProps = {
+  variant?: 'default' | 'github';
+  url?: string;
+};
+
+const LinkIconBox = ({ url, variant = 'github' }: LinkIconBoxProps) => {
+  return (
+    <Link href={url}>
+      <Flex
+        gap={2}
+        align={'center'}
+        role="group"
+      >
+        <Box
+          rounded={'full'}
+          w={'28px'}
+          h={'28px'}
+          bg={'gray.100'}
+          display={'flex'}
+          justifyContent={'center'}
+          alignItems={'center'}
+          role="group"
+          _groupHover={{
+            bg: 'gray.200',
+            fontColor: 'primary.700',
+            transform: 'translateY(-1px)',
+            transitionDuration: '0.25s',
+            transitionTimingFunction: 'ease-in-out',
+          }}
+        >
+          {variant === 'default' ? (
+            <LinkIcon
+              fontSize={'sm'}
+              color={'gray.800'}
+              _groupHover={{
+                color: 'primary.900',
+              }}
+            />
+          ) : (
+            <Icon
+              as={DiGithubAlt}
+              fontSize={'xl'}
+              color={'gray.800'}
+              _groupHover={{
+                color: 'primary.900',
+              }}
+            />
+          )}
+        </Box>
+        <Box color={'gray.700'}>
+          <Text fontSize={'sm'}>{url}</Text>
+        </Box>
+      </Flex>
+    </Link>
+  );
+};
+
+export default LinkIconBox;

--- a/src/components/organisms/ResumeBasicInput/ResumeBasicInput.tsx
+++ b/src/components/organisms/ResumeBasicInput/ResumeBasicInput.tsx
@@ -1,0 +1,121 @@
+import {
+  Box,
+  Flex,
+  Heading,
+  Input,
+  Text,
+  Textarea,
+  RadioGroup,
+  Radio,
+  Stack,
+} from '@chakra-ui/react';
+import LinkIconBox from './LinkIconBox';
+import TitleInput from '../../atoms/TitleInput/TitleInput';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { Button } from '~/components/atoms/Button';
+// import { FormTextInput } from '../../molecules/FormTextInput';
+
+const USER = {
+  NAME: '이민희',
+};
+
+const ResumeBasicInput = () => {
+  return (
+    <Flex
+      direction={'column'}
+      align={'center'}
+      gap={4}
+      width={'992px'}
+      id="resume-basic-input"
+    >
+      {/* NOTE 이력서 제목 */}
+      <Box
+        w={'full'}
+        mb={10}
+        display={'flex'}
+        alignItems={'center'}
+      >
+        <TitleInput />
+        <Button
+          size={'xs'}
+          ml={5}
+        >
+          저장
+        </Button>
+      </Box>
+
+      {/* NOTE 기본 정보 */}
+      <Box w={'full'}>
+        <Flex justifyContent={'space-between'}>
+          <Box w={'400px'}>
+            <Flex
+              direction={'column'}
+              gap={5}
+            >
+              <Heading>{USER.NAME}</Heading>
+              <Box>
+                <Flex
+                  justify={'space-between'}
+                  mb={3}
+                >
+                  {/* TODO 민희님이 만들어놓은 컴포넌트 사용할 것 */}
+                  <Text
+                    color={'gray.700'}
+                    fontWeight={'semibold'}
+                  >
+                    참고 링크
+                  </Text>
+                  <Button size={'xs'}>+</Button>
+                </Flex>
+                <Box>
+                  <LinkIconBox />
+                </Box>
+                <BorderBox p={5}>
+                  <Flex
+                    direction="column"
+                    gap={4}
+                  >
+                    <RadioGroup defaultValue="etc">
+                      <Stack
+                        spacing={4}
+                        direction={'row'}
+                      >
+                        <Radio value="etc">기타</Radio>
+                        <Radio value="github">Github</Radio>
+                        <Radio value="blog">Blog</Radio>
+                      </Stack>
+                    </RadioGroup>
+                    <Input placeholder="URL 입력" />
+                    <Button size={'xs'}>저장</Button>
+                  </Flex>
+                </BorderBox>
+              </Box>
+            </Flex>
+          </Box>
+          <BorderBox w={'400px'}>
+            <Box>
+              <Input
+                mb={3}
+                placeholder="희망 직무"
+              />
+              <Input
+                mb={3}
+                placeholder="보유한 기술 스택"
+              />
+              <Textarea
+                mb={3}
+                borderColor={'gray.300'}
+                placeholder="자기소개 (**자 이내)"
+              />
+              <Flex justify={'flex-end'}>
+                <Button size={'xs'}>저장</Button>
+              </Flex>
+            </Box>
+          </BorderBox>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};
+
+export default ResumeBasicInput;

--- a/src/components/organisms/ResumeBasicInput/ResumeBasicInput.tsx
+++ b/src/components/organisms/ResumeBasicInput/ResumeBasicInput.tsx
@@ -13,7 +13,6 @@ import LinkIconBox from './LinkIconBox';
 import TitleInput from '../../atoms/TitleInput/TitleInput';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
-// import { FormTextInput } from '../../molecules/FormTextInput';
 
 const USER = {
   NAME: '이민희',
@@ -67,8 +66,11 @@ const ResumeBasicInput = () => {
                   </Text>
                   <Button size={'xs'}>+</Button>
                 </Flex>
-                <Box>
-                  <LinkIconBox />
+                <Box mb={3}>
+                  <LinkIconBox
+                    url="https://github.com/khakhid"
+                    variant="github"
+                  />
                 </Box>
                 <BorderBox p={5}>
                   <Flex

--- a/src/components/organisms/ResumeBasicInput/index.ts
+++ b/src/components/organisms/ResumeBasicInput/index.ts
@@ -1,0 +1,1 @@
+export { default as ResumeBasicInput } from './ResumeBasicInput';

--- a/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 
 const HEADER_HEIGHT = 65;
+const FOOTER_HEIGHT = 430;
 
 const IMAGE = {
   SRC: 'src/assets/images/no-data.svg',
@@ -22,7 +23,7 @@ const BUTTON_CONTENT = {
 };
 
 const NotFoundPage = () => {
-  const pageHeight = `calc(100vh - ${HEADER_HEIGHT}px)`;
+  const pageHeight = `calc(100vh - ${HEADER_HEIGHT + FOOTER_HEIGHT}px)`;
 
   return (
     <>

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -12,6 +12,7 @@ const Layout = () => {
     >
       <Box
         position={'fixed'}
+        zIndex={'docked'}
         w={'full'}
         top={0}
         left={'50%'}

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -12,7 +12,7 @@ const Layout = () => {
     >
       <Box
         position={'fixed'}
-        zIndex={'docked'}
+        zIndex={'sticky'}
         w={'full'}
         top={0}
         left={'50%'}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/51f8b149-c03f-40fb-b936-257776041b42)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- **이력서 작성 페이지의 상단 기본 프로필 입력 부분의 레이아웃과 UI를 구현했습니다.**
  - 참고 링크 부분에 들어가는 링크 박스를 LinkIconBox 라는 개별 컴포넌트로 분리했습니다.
    - 아직 데이터를 받아 반복하는 로직 없이 단순히 화면에 보여주는 용도로만 작업했습니다.
  - 내부 form에 대한 컨트롤 로직은 아직 없습니다. (브랜치 분리해서 작업할 예정)
  - react-icons 라이브러리가 추가되었습니다. (깃허브 아이콘 사용해야 해요)
- 404 페이지에 이제 헤더와 푸터가 나올 것이므로 NotFoundPage 컴포넌트의 높이를 수정했습니다.
- **Header 컴포넌트가 상단에 고정되어서 스크롤마다 따라오게 변경되면서, 하위 <Outlet> 내용과 겹쳐 보이는 문제점이 있었습니다.**
  - Header 컴포넌트가 들어가는 부모 컴포넌트에 z-index 속성을 'docked'로 주어서 해결했습니다.
  - z-index 속성 값은 차크라UI의 기본 스타일 시스템 속성을 사용하는 게 좋을 것 같아요.
  - 예를 들어 docked는 10이고, dropdown, popover 등의 미리 지정되어 있는 z-index가 있습니다.


## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
### 참고링크 부분 헤더와 + 버튼
- 이 부분은 민희님이 작성해주신 컴포넌트로 변경할 예정입니다.

### 차크라 기본 스타일 시스템의 z-index
https://chakra-ui.com/docs/styled-system/theme#z-index-values
```tsx
import { extendTheme } from '@chakra-ui/react'

const zIndices = {
  hide: -1,
  auto: 'auto',
  base: 0,
  docked: 10,
  dropdown: 1000,
  sticky: 1100,
  banner: 1200,
  overlay: 1300,
  modal: 1400,
  popover: 1500,
  skipLink: 1600,
  toast: 1700,
  tooltip: 1800,
}
const theme = extendTheme({ zIndices, ...})
```

## 🔎 PR포인트 및 궁금한 점
- z-index 값을 그냥 base보다 큰 docked로 했는데 어떤 것에 적용하는지는 모른 상태로 적용했습니다,
  - sticky로 설정을 하는 게 나을까요?