### PR TITLE
Gmmq 158 feat: 소셜 (카카오) 로그인 연동

### DIFF
--- a/src/api/user/postOAuthSignIn.ts
+++ b/src/api/user/postOAuthSignIn.ts
@@ -1,0 +1,11 @@
+import { resumeMeAxios } from '../axios';
+
+const postOAuthSignIn = async (loginProvider: string, code: string) => {
+  const { data } = await resumeMeAxios.post('/v1/login/oauth2/code', {
+    loginProvider,
+    code,
+  });
+  return data;
+};
+
+export default postOAuthSignIn;

--- a/src/constants/environments.ts
+++ b/src/constants/environments.ts
@@ -1,5 +1,5 @@
 const { VITE_BASE_URL } = import.meta.env;
 
-export const environments = {
-  baseUrlEnv: VITE_BASE_URL,
+export const ENVIRONMENTS = {
+  BASE_URL_ENV: VITE_BASE_URL,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,8 @@
-const constants = {
-  signUpCacheKey: 'sign-up-cache-key',
+import { ENVIRONMENTS } from './environments';
+
+const CONSTANTS = {
+  ENVIRONMENTS,
+  SIGN_UP_CACHE_KEY: 'sign-up-cache-key',
 };
 
-export default constants;
+export default CONSTANTS;

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,5 @@
-const constants = {};
+const constants = {
+  signUpCacheKey: 'sign-up-cache-key',
+};
 
 export default constants;

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -1,0 +1,24 @@
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import { usePostOAuthSignIn } from '~/queries/usePostOAuthSignIn';
+
+const OAuthRedirectPage = () => {
+  const [params] = useSearchParams();
+  const code = params.get('code');
+  const navigate = useNavigate();
+
+  if (!code) {
+    throw new Error('소셜 로그인 중 에러가 발생했습니다. 코드를 읽어올 수 없습니다.');
+  }
+
+  usePostOAuthSignIn('kakao', code, ({ cacheKey, access, refresh }) => {
+    // 새로운 사용자가 로그인한 경우
+    if (cacheKey) {
+      navigate('/sign-up/common');
+    }
+    /**TODO - access, refresh 토큰 저장 */
+  });
+
+  return <></>;
+};
+
+export default OAuthRedirectPage;

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -1,5 +1,7 @@
+import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { usePostOAuthSignIn } from '~/queries/usePostOAuthSignIn';
+import { SignInCallback, usePostOAuthSignIn } from '~/queries/usePostOAuthSignIn';
+import { useCacheKeyStore } from '~/stores/useCacheKeyStore';
 
 const OAuthRedirectPage = () => {
   const [params] = useSearchParams();
@@ -10,13 +12,22 @@ const OAuthRedirectPage = () => {
     throw new Error('소셜 로그인 중 에러가 발생했습니다. 코드를 읽어올 수 없습니다.');
   }
 
-  usePostOAuthSignIn('kakao', code, ({ cacheKey, access, refresh }) => {
+  const setCacheKey = useCacheKeyStore((state) => state.setCacheKey);
+  const signInCallback: SignInCallback = ({ cacheKey }) => {
     // 새로운 사용자가 로그인한 경우
     if (cacheKey) {
+      setCacheKey(cacheKey);
       navigate('/sign-up/common');
+      return;
     }
     /**TODO - access, refresh 토큰 저장 */
-  });
+  };
+
+  const signInMutation = usePostOAuthSignIn('kakao', code, signInCallback);
+
+  useEffect(() => {
+    signInMutation.mutate();
+  }, []);
 
   return <></>;
 };

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -21,6 +21,8 @@ const OAuthRedirectPage = () => {
       return;
     }
     /**TODO - access, refresh 토큰 저장 */
+    navigate('/');
+    return;
   };
 
   const signInMutation = usePostOAuthSignIn('kakao', code, signInCallback);

--- a/src/pages/SignUpPages/CommonSignUpPage/CommonSignUpPage.tsx
+++ b/src/pages/SignUpPages/CommonSignUpPage/CommonSignUpPage.tsx
@@ -23,6 +23,7 @@ const CommonSignUpPage = () => {
   } = useForm();
 
   const onSubmit = (values: { [key: string]: string }) => {
+    /**TODO - cacheKey zustand 스토어에서 받아와서 가입 요청 시 api에 함께 전송하기 */
     return new Promise(() => {
       setTimeout(() => {
         alert(JSON.stringify(values, null, 2));

--- a/src/queries/usePostOAuthSignIn.ts
+++ b/src/queries/usePostOAuthSignIn.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import postOAuthSignIn from '~/api/user/postOAuthSignIn';
+
+type SignInCallback = ({
+  cacheKey,
+  access,
+  refresh,
+}: {
+  cacheKey: string;
+  access: string;
+  refresh: string;
+}) => void;
+
+export const usePostOAuthSignIn = (
+  loginProvider: string,
+  code: string,
+  signInCallback: SignInCallback,
+) => {
+  return useMutation({
+    mutationKey: [code],
+    mutationFn: () => postOAuthSignIn(loginProvider, code),
+    onSuccess: () => signInCallback,
+  });
+};

--- a/src/queries/usePostOAuthSignIn.ts
+++ b/src/queries/usePostOAuthSignIn.ts
@@ -1,15 +1,20 @@
 import { useMutation } from '@tanstack/react-query';
 import postOAuthSignIn from '~/api/user/postOAuthSignIn';
 
-type SignInCallback = ({
+type SignIn = {
+  access: string;
+  refresh: string;
+};
+
+export type SignInCallback = ({
   cacheKey,
   access,
   refresh,
-}: {
-  cacheKey: string;
-  access: string;
-  refresh: string;
-}) => void;
+}: Partial<
+  {
+    cacheKey?: string;
+  } & SignIn
+>) => void;
 
 export const usePostOAuthSignIn = (
   loginProvider: string,

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -45,6 +45,7 @@ const router = createBrowserRouter([
       { path: 'sign-up/mentee', element: <MenteeSignUpPage /> },
       { path: 'sign-up/mentor', element: <MentorSignUpPage /> },
       { path: 'sign-in', element: <SignInPage /> },
+      { path: 'sign-in/oauth/kakao', element: <OAuthRedirectPage /> },
 
       { path: 'admin', element: <AdminPage /> },
       { path: '*', element: <NotFoundPage /> },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -14,6 +14,7 @@ import { CommentResumePage } from '~/pages/ResumePages/CommentResumePage';
 import { CreateResumePage } from '~/pages/ResumePages/CreateResumePage';
 import { EditResumePage } from '~/pages/ResumePages/EditResumePage';
 import { ResumeDetailPage } from '~/pages/ResumePages/ResumeDetailPage';
+import OAuthRedirectPage from '~/pages/SignInPage/OAuthRedirectPage';
 import SignInPage from '~/pages/SignInPage/SignInPage';
 import { CommonSignUpPage } from '~/pages/SignUpPages/CommonSignUpPage';
 import { MenteeSignUpPage } from '~/pages/SignUpPages/MenteeSignUpPage';

--- a/src/stores/useCacheKeyStore.ts
+++ b/src/stores/useCacheKeyStore.ts
@@ -2,11 +2,16 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import constants from '~/constants';
 
-export const useCacheKeyStore = create(
+type CacheKeyState = {
+  cacheKey: string;
+  setCacheKey: (cacheKey: string) => void;
+};
+
+export const useCacheKeyStore = create<CacheKeyState>()(
   persist(
     (set) => ({
       cacheKey: '',
-      setCacheKey: () => set((cacheKey: string) => ({ cacheKey })),
+      setCacheKey: (cacheKey: string) => set({ cacheKey }),
     }),
     {
       name: constants.signUpCacheKey,

--- a/src/stores/useCacheKeyStore.ts
+++ b/src/stores/useCacheKeyStore.ts
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import constants from '~/constants';
 
-export const useSignUpCacheKey = create(
+export const useCacheKeyStore = create(
   persist(
     (set) => ({
       cacheKey: '',

--- a/src/stores/useCacheKeyStore.ts
+++ b/src/stores/useCacheKeyStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
-import constants from '~/constants';
+import CONSTANTS from '~/constants';
 
 type CacheKeyState = {
   cacheKey: string;
@@ -14,7 +14,7 @@ export const useCacheKeyStore = create<CacheKeyState>()(
       setCacheKey: (cacheKey: string) => set({ cacheKey }),
     }),
     {
-      name: constants.signUpCacheKey,
+      name: CONSTANTS.SIGN_UP_CACHE_KEY,
       storage: createJSONStorage(() => sessionStorage),
     },
   ),

--- a/src/stores/useSignUpCacheKey.ts
+++ b/src/stores/useSignUpCacheKey.ts
@@ -1,0 +1,16 @@
+import { create } from 'zustand';
+import { persist, createJSONStorage } from 'zustand/middleware';
+import constants from '~/constants';
+
+export const useSignUpCacheKey = create(
+  persist(
+    (set) => ({
+      cacheKey: '',
+      setCacheKey: () => set((cacheKey: string) => ({ cacheKey })),
+    }),
+    {
+      name: constants.signUpCacheKey,
+      storage: createJSONStorage(() => sessionStorage),
+    },
+  ),
+);


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 카카오 소셜 로그인 후 code를 카카오 서버로부터 받아오면 백엔드 서버에 전달하는 데까지 구현했습니다.


## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 기존 사용자인지 새로운 사용자인지에 따라 백엔드에서 주는 Response 값이 다릅니다.
- 새로운 사용자의 경우 cacheKey를 주는데, 이 cacheKey를 최종 가입 요청 보낼 때 함께 보내야 합니다.
- 따라서 cacheKey를 zustand persist를 사용하여 `useCacheKeyStore`를 만들어 로컬스토리지에 저장하도록 했습니다.
- 최종 가입 요청 시에는 스토어에서 cacheKey를 꺼내서 함께 보내면 됩니다.

## 🔎 PR포인트 및 궁금한 점
