### PR TITLE
Gmmq 173 feat: create event api 연결, 연결 관련 타입 수정

### DIFF
--- a/src/components/molecules/FormControl/index.stories.tsx
+++ b/src/components/molecules/FormControl/index.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta } from '@storybook/react';
-import { useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import FormControl from './FormControl';
 import { FormTextInput } from '../FormTextInput';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
 import { FormLabel } from '~/components/atoms/FormLabel';
+import { CreatePostProps } from '~/services/eventService';
 
 const meta = {
   title: 'Resumeme/Components/FormControl',
@@ -19,9 +20,9 @@ export const DefaultFormControl = () => {
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
-  } = useForm();
+  } = useForm<CreatePostProps>();
 
-  const onSubmit = (values: { [key: string]: string }) => {
+  const onSubmit: SubmitHandler<CreatePostProps> = (values) => {
     return new Promise(() => {
       setTimeout(() => {
         alert(JSON.stringify(values, null, 2));
@@ -32,9 +33,9 @@ export const DefaultFormControl = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <BorderBox>
-        <FormControl isInvalid={!!errors['title']}>
+        <FormControl isInvalid={!!errors.info?.title}>
           <FormLabel
-            htmlFor={'title'}
+            htmlFor={'info.title'}
             isRequired={true}
           >
             이벤트 제목
@@ -42,9 +43,9 @@ export const DefaultFormControl = () => {
 
           <FormTextInput
             w={'100%'}
-            id="title"
-            register={{ ...register('title', { required: true }) }}
-            errors={errors}
+            id="info.title"
+            register={{ ...register('info.title', { required: true }) }}
+            error={errors.info?.title}
             placeholder="이벤트 제목을 입력해주세요."
           />
         </FormControl>
@@ -67,9 +68,9 @@ export const ColumnFormControl = () => {
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
-  } = useForm();
+  } = useForm<CreatePostProps>();
 
-  const onSubmit = (values: { [key: string]: string }) => {
+  const onSubmit: SubmitHandler<CreatePostProps> = (values) => {
     return new Promise(() => {
       setTimeout(() => {
         alert(JSON.stringify(values, null, 2));
@@ -82,11 +83,10 @@ export const ColumnFormControl = () => {
       <BorderBox>
         <FormControl
           direction="column"
-          spacing="0.5rem"
-          isInvalid={!!errors['title']}
+          isInvalid={!!errors.info?.title}
         >
           <FormLabel
-            htmlFor={'title'}
+            htmlFor={'info.title'}
             isRequired={true}
           >
             이벤트 제목
@@ -94,9 +94,9 @@ export const ColumnFormControl = () => {
 
           <FormTextInput
             w={'100%'}
-            id="title"
-            register={{ ...register('title', { required: true }) }}
-            errors={errors}
+            id="info.title"
+            register={{ ...register('info.title', { required: true }) }}
+            error={errors.info?.title}
             placeholder="이벤트 제목을 입력해주세요."
           />
         </FormControl>

--- a/src/components/molecules/FormTextInput/FormTextInput.tsx
+++ b/src/components/molecules/FormTextInput/FormTextInput.tsx
@@ -1,13 +1,15 @@
 import { Input, InputProps, FormErrorMessage, Flex } from '@chakra-ui/react';
-import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
 
 type FormTextInputProps = {
   id: string;
   register: UseFormRegisterReturn;
-  error?: FieldError;
+  error?: FieldError | FieldErrors;
 } & Omit<InputProps, 'type'>;
 
 const FormTextInput = ({ id, register, error, ...props }: FormTextInputProps) => {
+  const errorMessage = error && 'message' in error ? (error.message as string) : '';
+
   return (
     <Flex
       direction={'column'}
@@ -18,7 +20,7 @@ const FormTextInput = ({ id, register, error, ...props }: FormTextInputProps) =>
         {...props}
         {...register}
       />
-      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
+      {error && <FormErrorMessage>{errorMessage}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextInput/FormTextInput.tsx
+++ b/src/components/molecules/FormTextInput/FormTextInput.tsx
@@ -1,13 +1,13 @@
 import { Input, InputProps, FormErrorMessage, Flex } from '@chakra-ui/react';
-import { FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 type FormTextInputProps = {
   id: string;
   register: UseFormRegisterReturn;
-  errors?: FieldErrors;
+  error?: FieldError;
 } & Omit<InputProps, 'type'>;
 
-const FormTextInput = ({ id, register, errors, ...props }: FormTextInputProps) => {
+const FormTextInput = ({ id, register, error, ...props }: FormTextInputProps) => {
   return (
     <Flex
       direction={'column'}
@@ -18,7 +18,7 @@ const FormTextInput = ({ id, register, errors, ...props }: FormTextInputProps) =
         {...props}
         {...register}
       />
-      {errors && <FormErrorMessage>{errors[id]?.message as string}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextInput/index.stories.tsx
+++ b/src/components/molecules/FormTextInput/index.stories.tsx
@@ -1,10 +1,11 @@
 import type { Meta } from '@storybook/react';
-import { useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import FormTextInput from './FormTextInput';
 import FormControl from '../FormControl/FormControl';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
 import { FormLabel } from '~/components/atoms/FormLabel';
+import { CreatePostProps } from '~/services/eventService';
 
 const meta = {
   title: 'Resumeme/Components/FormTextInput',
@@ -19,9 +20,9 @@ export const DefaultFormTextInput = () => {
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
-  } = useForm();
+  } = useForm<CreatePostProps>();
 
-  const onSubmit = (values: { [key: string]: string }) => {
+  const onSubmit: SubmitHandler<CreatePostProps> = (values) => {
     return new Promise(() => {
       setTimeout(() => {
         alert(JSON.stringify(values, null, 2));
@@ -32,9 +33,9 @@ export const DefaultFormTextInput = () => {
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <BorderBox>
-        <FormControl isInvalid={!!errors['title']}>
+        <FormControl isInvalid={!!errors.info?.title}>
           <FormLabel
-            htmlFor={'title'}
+            htmlFor={'info.title'}
             isRequired={true}
           >
             이벤트 제목
@@ -42,9 +43,9 @@ export const DefaultFormTextInput = () => {
 
           <FormTextInput
             w={'100%'}
-            id="title"
-            register={{ ...register('title', { required: true }) }}
-            errors={errors}
+            id="info.title"
+            register={{ ...register('info.title', { required: true }) }}
+            error={errors.info?.title}
             placeholder="이벤트 제목을 입력해주세요."
           />
         </FormControl>

--- a/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
+++ b/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
@@ -1,14 +1,14 @@
 import { CheckboxGroup, CheckboxGroupProps, Stack } from '@chakra-ui/react';
-import { Controller, Control } from 'react-hook-form';
+import { Controller, Control, FieldValues, Path } from 'react-hook-form';
 import CheckboxStyled from './CheckboxStyled';
 
-export type LabelCheckboxGroupProps = CheckboxGroupProps & {
+export type LabelCheckboxGroupProps<T extends FieldValues> = CheckboxGroupProps & {
   options?: Array<{ label: string; value: string }>;
   variant?: 'role' | 'domain' | 'default';
   spacing?: string;
-  name: string;
+  name: Path<T>;
   required?: boolean;
-  control: Control;
+  control: Control<T>;
 };
 
 const role = [
@@ -28,7 +28,7 @@ const domain = [
   { label: '포털/콘텐츠/메신저', value: 'portal' },
 ];
 
-const LabelCheckboxGroup = ({
+const LabelCheckboxGroup = <T extends FieldValues>({
   options,
   variant = 'default',
   spacing = '12px',
@@ -36,7 +36,7 @@ const LabelCheckboxGroup = ({
   control,
   required = true,
   ...props
-}: LabelCheckboxGroupProps) => {
+}: LabelCheckboxGroupProps<T>) => {
   let selectedOptions = options;
 
   if (variant != 'default') {

--- a/src/components/molecules/TermInput/TermInput.tsx
+++ b/src/components/molecules/TermInput/TermInput.tsx
@@ -1,20 +1,27 @@
 import { Divider, HStack, FormControl } from '@chakra-ui/react';
-import { UseFormRegister, FieldValues, FieldErrors, Control, useWatch } from 'react-hook-form';
+import {
+  UseFormRegister,
+  FieldValues,
+  FieldErrors,
+  Control,
+  useWatch,
+  Path,
+} from 'react-hook-form';
 import { FormDateInput } from '~/components/molecules/FormDateInput';
 import { getOneYearLater } from '~/utils/getOneYearLater';
 
-type TermInputProps = {
-  startDateName: string;
-  endDateName: string;
+type TermInputProps<T extends FieldValues> = {
+  startDateName: Path<T>;
+  endDateName: Path<T>;
   isEndDateDisabled?: boolean;
   isRequired?: boolean;
   includeTime?: boolean;
-  register: UseFormRegister<FieldValues>;
-  errors: FieldErrors<FieldValues>;
-  control: Control;
+  register: UseFormRegister<T>;
+  errors: FieldErrors<T>;
+  control: Control<T>;
 };
 
-const TermInput = ({
+const TermInput = <T extends FieldValues>({
   startDateName,
   endDateName,
   isEndDateDisabled = false,
@@ -23,9 +30,10 @@ const TermInput = ({
   register,
   errors,
   control,
-}: TermInputProps) => {
+}: TermInputProps<T>) => {
   /*TODO - isEndDateDisabled 상태 변화 시 리렌더링되도록 수정하기 */
   const startDate = useWatch({ name: startDateName, control });
+
   return (
     <HStack flexGrow={1}>
       <FormControl isInvalid={!!errors[startDateName]}>

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -65,7 +65,7 @@ const CareerForm = () => {
           <FormTextInput
             id="companyName"
             register={{ ...register('companyName', { required: '회사명을 입력하세요' }) }}
-            errors={errors}
+            error={errors.companyName}
           />
         </FormControl>
         <Flex
@@ -95,7 +95,7 @@ const CareerForm = () => {
           <FormTextInput
             id="position"
             register={{ ...register('position', { required: '직무를 입력하세요.' }) }}
-            errors={errors}
+            error={errors.position}
           />
         </FormControl>
         <FormControl>

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -98,7 +98,7 @@ const CreateEventTemplate = () => {
             </FormControl>
             <HStack spacing={'1.6rem'}>
               <FormLabel isRequired={true}>신청 기간</FormLabel>
-              <TermInput
+              <TermInput<CreatePostProps>
                 control={control}
                 includeTime={true}
                 errors={errors}

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -9,8 +9,11 @@ import { FormDateInput } from '~/components/molecules/FormDateInput';
 import FormTextInput from '~/components/molecules/FormTextInput/FormTextInput';
 import { LabelCheckboxGroup } from '~/components/molecules/LabelCheckboxGroup';
 import { TermInput } from '~/components/molecules/TermInput';
+import { CreatePostProps, useCreateEvent } from '~/services/eventService';
 
 const CreateEventTemplate = () => {
+  const { mutate: createEvent, isLoading } = useCreateEvent();
+
   const {
     control,
     handleSubmit,
@@ -18,12 +21,13 @@ const CreateEventTemplate = () => {
     formState: { errors, isSubmitting },
   } = useForm();
 
-  const onSubmit = (values: { [key: string]: string }) => {
-    return new Promise(() => {
-      setTimeout(() => {
-        alert(JSON.stringify(values, null, 2));
-      }, 3000);
-    });
+  const onSubmit: SubmitHandler<CreatePostProps> = (values) => {
+    createEvent(values);
+    // return new Promise(() => {
+    //   setTimeout(() => {
+    //     alert(JSON.stringify(values, null, 2));
+    //   }, 3000);
+    // });
   };
 
   return (

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -1,5 +1,5 @@
 import { HStack, Flex, Text } from '@chakra-ui/react';
-import { useForm } from 'react-hook-form';
+import { useForm, SubmitHandler } from 'react-hook-form';
 import { FormTextarea } from './../../molecules/FormTextarea';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
@@ -19,7 +19,7 @@ const CreateEventTemplate = () => {
     handleSubmit,
     register,
     formState: { errors, isSubmitting },
-  } = useForm();
+  } = useForm<CreatePostProps>();
 
   const onSubmit: SubmitHandler<CreatePostProps> = (values) => {
     createEvent(values);
@@ -29,6 +29,8 @@ const CreateEventTemplate = () => {
     //   }, 3000);
     // });
   };
+
+  //목업 데이터 생성
 
   return (
     <>
@@ -46,9 +48,9 @@ const CreateEventTemplate = () => {
             direction={'column'}
             gap={'1.25rem'}
           >
-            <FormControl isInvalid={!!errors['title']}>
+            <FormControl isInvalid={!!errors.info?.title}>
               <FormLabel
-                htmlFor={'title'}
+                htmlFor={'info.title'}
                 isRequired={true}
               >
                 이벤트 제목
@@ -56,30 +58,30 @@ const CreateEventTemplate = () => {
 
               <FormTextInput
                 w={'100%'}
-                id="title"
-                register={{ ...register('title', { required: true }) }}
-                errors={errors}
+                id="info.title"
+                register={{ ...register('info.title', { required: true }) }}
+                error={errors.info?.title}
                 placeholder="이벤트 제목을 입력해주세요."
               />
             </FormControl>
-            <FormControl isInvalid={!!errors['maximumAttendee']}>
+            <FormControl isInvalid={!!errors.info?.maximumAttendee}>
               <FormLabel
-                htmlFor={'maximumAttendee'}
+                htmlFor={'info.maximumAttendee'}
                 isRequired={true}
               >
                 인원 수
               </FormLabel>
               <FormTextInput
-                id="maximumAttendee"
+                id="info.maximumAttendee"
                 register={{
-                  ...register('maximumAttendee', {
+                  ...register('info.maximumAttendee', {
                     required: true,
                     max: { value: 10, message: '10이하로 입력해 주세요.' },
                     min: { value: 2, message: '2이상 입력해 주세요.' },
                     pattern: { value: /^(?:[2-9]|10)$/, message: '숫자를 입력해 주세요.' },
                   }),
                 }}
-                errors={errors}
+                error={errors.info?.maximumAttendee}
                 placeholder="신청 받을 인원 수(2~10)를 입력해주세요."
               />
             </FormControl>
@@ -87,12 +89,7 @@ const CreateEventTemplate = () => {
               spacing="1.63rem"
               isInvalid={!!errors['positions']}
             >
-              <FormLabel
-                htmlFor={'positions'}
-                isRequired={true}
-              >
-                직무
-              </FormLabel>
+              <FormLabel isRequired={true}>직무</FormLabel>
               <LabelCheckboxGroup
                 control={control}
                 name="positions"
@@ -107,32 +104,32 @@ const CreateEventTemplate = () => {
                 errors={errors}
                 register={register}
                 isRequired={true}
-                endDateName="closeDateTime"
-                startDateName="openDateTime"
+                endDateName="time.closeDateTime"
+                startDateName="time.openDateTime"
               />
             </HStack>
-            <FormControl isInvalid={!!errors['endDate']}>
+            <FormControl isInvalid={!!errors.time?.endDate}>
               <FormLabel isRequired={true}>첨삭 종료일</FormLabel>
               <FormDateInput
-                name="endDate"
+                name={'time.endDate'}
                 w={'47.6%'}
-                register={{ ...register('endDate', { required: true }) }}
+                register={{ ...register('time.endDate', { required: true }) }}
               />
             </FormControl>
             <FormControl
               spacing="1.63rem"
-              isInvalid={!!errors['content']}
+              isInvalid={!!errors.info?.content}
             >
               <FormLabel
-                htmlFor={'content'}
+                htmlFor={'info.content'}
                 isRequired={true}
               >
                 내용
               </FormLabel>
               <FormTextarea
                 errors={errors}
-                id="content"
-                register={{ ...register('content', { required: true }) }}
+                id="info.content"
+                register={{ ...register('info.content', { required: true }) }}
                 placeholder="이벤트에 대한 상세 내용을 입력해주세요."
               />
             </FormControl>

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -12,7 +12,7 @@ import { TermInput } from '~/components/molecules/TermInput';
 import { CreatePostProps, useCreateEvent } from '~/services/eventService';
 
 const CreateEventTemplate = () => {
-  const { mutate: createEvent, isLoading } = useCreateEvent();
+  const { mutate: createEvent } = useCreateEvent();
 
   const {
     control,

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -1,0 +1,25 @@
+import { useMutation } from '@tanstack/react-query';
+import { resumeMeAxios } from '~/api/axios';
+
+export type CreatePostProps = {
+  info: {
+    title: string;
+    content: string;
+    maximumAttendee: number;
+  };
+  time: {
+    now: string;
+    openDateTime: string;
+    closeDateTime: string;
+    endDate: string;
+  };
+  positions: string[];
+};
+
+const createEvent = async (data: CreatePostProps) => {
+  return await resumeMeAxios.post('/api/v1/events', { ...data });
+};
+
+export const useCreateEvent = () => {
+  return useMutation({ mutationFn: createEvent });
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
UI에 이어서 api를 연결했습니다.


## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
api에 관련된 Type을 설정해서 form에서 값을 받을 때 api request type으로 한정지었습니다

이에 관련해서 컴포넌트 들의 타입이 수정되었습니다.
PR은 조금 있다가 수정하겠습니다.
```tsx
type TermInputProps<T extends FieldValues> = { //FieldValues를 확장하는 제네릭ㅇ르 선언합니다.
  startDateName: Path<T>; 
  endDateName: Path<T>;
  isEndDateDisabled?: boolean;
  isRequired?: boolean;
  includeTime?: boolean;
  register: UseFormRegister<T>;
  errors: FieldErrors<T>;
  control: Control<T>;
};
```

## 🔎 PR포인트 및 궁금한 점
