### PR TITLE
GMMQ 282 feat: MainTextarea 공통 컴포넌트 개발

### DIFF
--- a/src/components/atoms/MainTextarea/MainTextarea.tsx
+++ b/src/components/atoms/MainTextarea/MainTextarea.tsx
@@ -1,0 +1,30 @@
+import { Textarea, TextareaProps, FormErrorMessage, Flex } from '@chakra-ui/react';
+import { UseFormRegisterReturn, FieldErrors } from 'react-hook-form';
+
+type MainTextareaProps = {
+  id: string;
+  register: UseFormRegisterReturn;
+  errors?: FieldErrors;
+} & Omit<TextareaProps, 'type'>;
+
+const MainTextarea = ({ id, register, errors, ...props }: MainTextareaProps) => {
+  return (
+    <>
+      <Flex
+        direction={'column'}
+        flexGrow={1}
+      >
+        <Textarea
+          id={id}
+          {...props}
+          {...register}
+          borderColor="gray.300"
+          focusBorderColor="primary.900"
+        />
+        {errors && <FormErrorMessage>{errors![id]?.message as string}</FormErrorMessage>}
+      </Flex>
+    </>
+  );
+};
+
+export default MainTextarea;

--- a/src/components/atoms/MainTextarea/index.stories.tsx
+++ b/src/components/atoms/MainTextarea/index.stories.tsx
@@ -1,0 +1,77 @@
+import { FormControl, Flex } from '@chakra-ui/react';
+import type { Meta } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import MainTextarea from './MainTextarea';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { Button } from '~/components/atoms/Button';
+import FormLabel from '~/components/atoms/FormLabel/FormLabel';
+
+const meta = {
+  title: 'Resumeme/Components/MainTextarea',
+  component: MainTextarea,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof MainTextarea>;
+
+export default meta;
+
+export const DefaultMainTextarea = () => {
+  const {
+    handleSubmit,
+    register,
+    formState: { errors, isSubmitting },
+  } = useForm();
+
+  const onSubmit = (values: { [key: string]: string }) => {
+    return new Promise(() => {
+      setTimeout(() => {
+        alert(JSON.stringify(values, null, 2));
+      }, 1000);
+    });
+  };
+
+  const FORM = {
+    LABEL: '자기소개',
+    KEY: 'introduce',
+    PLACEHOLDER: '내용을 10자 이하로 입력해주세요.',
+    ERROR_MESSAGE: '10자 이하로 입력해주세요.',
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <BorderBox>
+        <FormControl
+          isInvalid={!!errors[FORM.KEY]}
+          key={FORM.KEY}
+        >
+          <Flex
+            direction={'column'}
+            gap={5}
+            width={'500px'}
+          >
+            <FormLabel htmlFor={FORM.KEY}>{FORM.LABEL}</FormLabel>
+            <MainTextarea
+              id={FORM.KEY}
+              register={{
+                ...register(FORM.KEY, {
+                  maxLength: { value: 10, message: FORM.ERROR_MESSAGE },
+                }),
+              }}
+              errors={errors}
+              placeholder={FORM.PLACEHOLDER}
+            />
+          </Flex>
+        </FormControl>
+      </BorderBox>
+      <Button
+        size="md"
+        isLoading={isSubmitting}
+        type="submit"
+      >
+        확인
+      </Button>
+    </form>
+  );
+};

--- a/src/components/atoms/MainTextarea/index.ts
+++ b/src/components/atoms/MainTextarea/index.ts
@@ -1,0 +1,1 @@
+export { default as MainTextarea } from './MainTextarea';

--- a/src/theme/components/index.ts
+++ b/src/theme/components/index.ts
@@ -1,5 +1,6 @@
 import { Avatar } from './avatar';
 import { Button } from './button';
 import { Input } from './input';
+import { Textarea } from './textarea';
 
-export { Input, Button, Avatar };
+export { Input, Button, Avatar, Textarea };

--- a/src/theme/components/textarea.ts
+++ b/src/theme/components/textarea.ts
@@ -1,0 +1,25 @@
+import { defineStyle, defineStyleConfig } from '@chakra-ui/styled-system';
+
+const variantOutline = defineStyle(() => {
+  return {
+    _placeholder: { color: 'gray.400' },
+    _focusVisible: {
+      boxShadow: '0',
+      _invalid: { borderColor: 'red', boxShadow: '0' },
+    },
+    boxShadow: '0',
+    border: '1px solid',
+    borderColor: 'gray.300',
+    h: '3.125rem',
+  };
+});
+
+const variants = {
+  outline: variantOutline,
+};
+
+const Textarea = defineStyleConfig({
+  variants,
+});
+
+export { Textarea };

--- a/src/theme/index.tsx
+++ b/src/theme/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable */
 
 import { StyleFunctionProps, extendTheme } from '@chakra-ui/react';
-import { Input, Button, Avatar } from '~/theme/components';
+import { Input, Button, Avatar, Textarea } from '~/theme/components';
 
 const theme = extendTheme({
   breakpoints: {
@@ -79,7 +79,7 @@ const theme = extendTheme({
     '8xl': '6rem',
     '9xl': '8rem',
   },
-  components: { Input, Button, Avatar },
+  components: { Input, Button, Avatar, Textarea },
 });
 
 export default theme;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/96dcb7a0-e14e-4a37-9eb9-f68cd073118e)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- MainTextarea 공통 컴포넌트 개발

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
### Props
- `id`: string
- `register`: UseFormRegisterReturn
- `errors`: FieldErrors
- `...props`: 기본 input 또는 차크라 Input 컴포넌트 프로퍼티



### 문제점
![image](https://github.com/resumeme/Frontend/assets/74141521/2d21876e-6164-4f32-abf9-f4e4988cb1f8)
- Form Validation이 발생한 상황에서
  - MainTextarea에 focus되었을 때의 borderColor가 error borderColor를 덮어씌워버립니다.
  - 밸리데이션에 통과하지 못하면 보더가 빨간색이 되어야 하는데, primary 색입니다. focus를 벗어나면 빨간색으로 보이네요.
  - 이 부분 어떻게 해결해야 하는 지 잘 모르겠네요.
- 다른 분들 공통 컴포넌트도 비슷하더라구요.


## 🔎 PR포인트 및 궁금한 점
