### PR TITLE
Gmmq 174 feat: 이력서 업무경험 작성 api 연결

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,6 +12,7 @@ const config: StorybookConfig = {
     '@storybook/addon-onboarding',
     '@storybook/addon-interactions',
     '@chakra-ui/storybook-addon',
+    'storybook-addon-react-router-v6',
   ],
   framework: {
     name: '@storybook/react-vite',

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react';
+import { withRouter } from 'storybook-addon-react-router-v6';
 import theme from '../src/theme';
 
 const preview: Preview = {
@@ -14,6 +15,7 @@ const preview: Preview = {
       theme,
     },
   },
+  decorators: [withRouter],
 };
 
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "lint-staged": "^15.0.2",
         "prettier": "^3.0.3",
         "storybook": "^7.5.0",
+        "storybook-addon-react-router-v6": "^2.0.9",
         "typescript": "^5.0.2",
         "vite": "^4.4.5"
       }
@@ -8647,6 +8648,12 @@
       "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
       "dev": true
     },
+    "node_modules/compare-versions": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-6.1.0.tgz",
+      "integrity": "sha512-LNZQXhqUvqUTotpZ00qLSaify3b4VFD588aRr8MKFw4CMUr98ytzCW5wDH5qx/DEY5kCDXcbcRuCqL0szEf2tg==",
+      "dev": true
+    },
     "node_modules/compressible": {
       "version": "2.0.18",
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -15350,6 +15357,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
+      }
+    },
+    "node_modules/storybook-addon-react-router-v6": {
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/storybook-addon-react-router-v6/-/storybook-addon-react-router-v6-2.0.9.tgz",
+      "integrity": "sha512-xqM9H+GpzSV6cz9IjlNeP31HXjif3E9KG3gJ1ouPzuOTGeEYyvWc7v2z+9mO5m3uO46OyympbHMJGdeEIQ+wdA==",
+      "dev": true,
+      "dependencies": {
+        "compare-versions": "^6.0.0",
+        "react-inspector": "6.0.2"
+      },
+      "peerDependencies": {
+        "@storybook/blocks": "^7.0.0",
+        "@storybook/channels": "^7.0.0",
+        "@storybook/components": "^7.0.0",
+        "@storybook/core-events": "^7.0.0",
+        "@storybook/manager-api": "^7.0.0",
+        "@storybook/preview-api": "^7.0.0",
+        "@storybook/theming": "^7.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.4.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/stream-shift": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "lint-staged": "^15.0.2",
     "prettier": "^3.0.3",
     "storybook": "^7.5.0",
+    "storybook-addon-react-router-v6": "^2.0.9",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   },

--- a/src/api/resume/create/postResumeCareer.ts
+++ b/src/api/resume/create/postResumeCareer.ts
@@ -1,0 +1,15 @@
+import { isAxiosError } from 'axios';
+import { resumeMeAxios } from '~/api/axios';
+import Career from '~/types/career';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+
+export const postResumeCareer = async (resumeId: number, resumeCareer: Career) => {
+  try {
+    const { data } = await resumeMeAxios.post(`/resume.../${resumeId}`, resumeCareer);
+    return data;
+  } catch (e) {
+    if (isAxiosError<ResumeMeErrorResponse>(e)) {
+      throw new Error(e.response?.data.message);
+    }
+  }
+};

--- a/src/api/resume/create/postResumeCareer.ts
+++ b/src/api/resume/create/postResumeCareer.ts
@@ -5,7 +5,7 @@ import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
 export const postResumeCareer = async (resumeId: string, resumeCareer: Career) => {
   try {
-    const { data } = await resumeMeAxios.post(`/api/v1/resume/${resumeId}/careers`, resumeCareer, {
+    const { data } = await resumeMeAxios.post(`/v1/resume/${resumeId}/careers`, resumeCareer, {
       headers: {
         /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
         access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,

--- a/src/api/resume/create/postResumeCareer.ts
+++ b/src/api/resume/create/postResumeCareer.ts
@@ -5,7 +5,12 @@ import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
 export const postResumeCareer = async (resumeId: string, resumeCareer: Career) => {
   try {
-    const { data } = await resumeMeAxios.post(`/api/v1/resume/${resumeId}/careers`, resumeCareer);
+    const { data } = await resumeMeAxios.post(`/api/v1/resume/${resumeId}/careers`, resumeCareer, {
+      headers: {
+        /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+        access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+      },
+    });
     return data;
   } catch (e) {
     if (isAxiosError<ResumeMeErrorResponse>(e)) {

--- a/src/api/resume/create/postResumeCareer.ts
+++ b/src/api/resume/create/postResumeCareer.ts
@@ -3,9 +3,9 @@ import { resumeMeAxios } from '~/api/axios';
 import Career from '~/types/career';
 import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
-export const postResumeCareer = async (resumeId: number, resumeCareer: Career) => {
+export const postResumeCareer = async (resumeId: string, resumeCareer: Career) => {
   try {
-    const { data } = await resumeMeAxios.post(`/resume.../${resumeId}`, resumeCareer);
+    const { data } = await resumeMeAxios.post(`/api/v1/resume/${resumeId}/careers`, resumeCareer);
     return data;
   } catch (e) {
     if (isAxiosError<ResumeMeErrorResponse>(e)) {

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -36,7 +36,6 @@ const CareerForm = () => {
     formState: { errors },
   } = useForm<Career>();
 
-  /**TODO remove 기능 추가하기 */
   const { fields, append, remove } = useFieldArray({
     control,
     name: 'duties',

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -50,7 +50,12 @@ const CareerForm = () => {
       navigate(-1);
       return;
     }
-    mutate({ resumeId, resumeCareer });
+    const skillsArr = resumeCareer.skills?.toString().split(/,+\s*/g);
+    const newResumeCareer = {
+      ...resumeCareer,
+      skills: skillsArr ?? [],
+    };
+    mutate({ resumeId, resumeCareer: newResumeCareer });
   });
 
   const defaultDutyData = {

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -12,19 +12,21 @@ import React from 'react';
 import {
   Control,
   FieldErrors,
-  FieldValues,
   UseFieldArrayRemove,
   UseFormRegister,
   useFieldArray,
   useForm,
   useWatch,
 } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 import FormLabel from '~/components/atoms/FormLabel/FormLabel';
 import { FormControl } from '~/components/molecules/FormControl';
 import { FormTextInput } from '~/components/molecules/FormTextInput';
 
 import { TermInput } from '~/components/molecules/TermInput';
+import { usePostResumeCareer } from '~/queries/resume/create/usePostResumeCareer';
+import Career from '~/types/career';
 
 const CareerForm = () => {
   const {
@@ -32,7 +34,7 @@ const CareerForm = () => {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm();
+  } = useForm<Career>();
 
   /**TODO remove 기능 추가하기 */
   const { fields, append, remove } = useFieldArray({
@@ -40,9 +42,16 @@ const CareerForm = () => {
     name: 'duties',
   });
 
-  const onSubmit = handleSubmit((values) => {
-    /**TODO api 호출해 저장하기 */
-    console.log('values', values);
+  const { id: resumeId } = useParams();
+  const { mutate } = usePostResumeCareer();
+  const navigate = useNavigate();
+  const onSubmit = handleSubmit((resumeCareer) => {
+    if (!resumeId) {
+      alert('존재하지 않는 이력서입니다.');
+      navigate(-1);
+      return;
+    }
+    mutate({ resumeId, resumeCareer });
   });
 
   const defaultDutyData = {
@@ -108,8 +117,8 @@ const CareerForm = () => {
         <FormControl>
           <FormLabel>기타 설명</FormLabel>
           <FormTextInput
-            id="others"
-            register={{ ...register('others') }}
+            id="careerContent"
+            register={{ ...register('careerContent') }}
           />
         </FormControl>
         {fields?.map((field, index) => (
@@ -156,10 +165,10 @@ const DutyForm = ({
 }: {
   key: string;
   index: number;
-  errors: FieldErrors<FieldValues>;
-  register: UseFormRegister<FieldValues>;
+  errors: FieldErrors<Career>;
+  register: UseFormRegister<Career>;
   remove: UseFieldArrayRemove;
-  control: Control;
+  control: Control<Career>;
 }) => {
   return (
     <React.Fragment key={key}>

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -50,6 +50,7 @@ const CareerForm = () => {
       navigate(-1);
       return;
     }
+    /**TODO: 기술스택 배열로 만드는 util 함수로 대체하기 */
     const skillsArr = resumeCareer.skills?.toString().split(/,+\s*/g);
     const newResumeCareer = {
       ...resumeCareer,

--- a/src/components/organisms/ResumeCategoryCareer/ResumeCategoryCareer.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/ResumeCategoryCareer.tsx
@@ -4,9 +4,9 @@ import { BorderBox } from '~/components/atoms/BorderBox';
 import { CategoryAddHeader } from '~/components/molecules/CategoryAddHeader';
 import CareerForm from '~/components/organisms/ResumeCategoryCareer/CareerForm';
 import { useStorage } from '~/hooks/useStorage';
-import { DefaultCareer } from '~/types/career';
+import Career from '~/types/career';
 
-const careerDefaultItem: DefaultCareer = {
+const careerDefaultItem: Career = {
   companyName: '',
   position: '',
   isCurrentlyEmployed: false,
@@ -20,7 +20,7 @@ const ResumeCategoryCareer = () => {
    * 저장한 값을 불러와서 map으로 돌린다
    * FIXME useState를 zustand store에서 불러오도록 수정하기
    */
-  const { storageValue: careerItems, setValue } = useStorage<DefaultCareer[]>({
+  const { storageValue: careerItems, setValue } = useStorage<Career[]>({
     key: CAREER_ITEMS_KEY,
     initialValue: [],
   });

--- a/src/components/organisms/ResumeCategoryCareer/index.stories.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import ResumeCategoryCareer from './ResumeCategoryCareer';
 
 const meta = {
@@ -9,6 +10,16 @@ const meta = {
   },
   tags: ['autodocs'],
   argTypes: {},
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient();
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
 } satisfies Meta<typeof ResumeCategoryCareer>;
 
 export default meta;

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,0 +1,11 @@
+import { ResumeCategoryCareer } from '~/components/organisms/ResumeCategoryCareer';
+
+const EditResumeTemplate = () => {
+  return (
+    <>
+      <ResumeCategoryCareer />
+    </>
+  );
+};
+
+export default EditResumeTemplate;

--- a/src/components/templates/EditResumeTemplate/index.ts
+++ b/src/components/templates/EditResumeTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as EditResumeTemplate } from './EditResumeTemplate';

--- a/src/pages/ResumePages/EditResumePage/EditResumePage.tsx
+++ b/src/pages/ResumePages/EditResumePage/EditResumePage.tsx
@@ -1,5 +1,7 @@
+import { EditResumeTemplate } from '~/components/templates/EditResumeTemplate';
+
 const EditResumePage = () => {
-  return <></>;
+  return <EditResumeTemplate />;
 };
 
 export default EditResumePage;

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
+import Career from '~/types/career';
+
+export const usePostResumeCareer = (resumeId: number, resumeCareer: Career) => {
+  return useMutation({
+    mutationKey: ['postCareer', resumeId],
+    mutationFn: () => postResumeCareer(resumeId, resumeCareer),
+  });
+};

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -2,9 +2,12 @@ import { useMutation } from '@tanstack/react-query';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
 import Career from '~/types/career';
 
-export const usePostResumeCareer = (resumeId: number, resumeCareer: Career) => {
+type UsePostResumeCareer = { resumeId: string; resumeCareer: Career };
+
+export const usePostResumeCareer = () => {
   return useMutation({
-    mutationKey: ['postCareer', resumeId],
-    mutationFn: () => postResumeCareer(resumeId, resumeCareer),
+    mutationKey: ['postCareer'],
+    mutationFn: ({ resumeId, resumeCareer }: UsePostResumeCareer) =>
+      postResumeCareer(resumeId, resumeCareer),
   });
 };

--- a/src/types/career.ts
+++ b/src/types/career.ts
@@ -1,30 +1,19 @@
-import { DateString } from './dateString';
-
-export default interface Career {
+type Career = {
   companyName: string;
   position: string;
   skills?: string[];
   duties?: Duty[];
   isCurrentlyEmployed: boolean;
-  careerStartDate: DateString;
-  endDate?: DateString;
+  careerStartDate: string;
+  endDate?: string;
   careerContent: string;
-}
+};
 
-export interface Duty {
+export default Career;
+
+type Duty = {
   title?: string;
   description?: string;
-  startDate?: DateString;
-  endDate?: DateString;
-}
-
-export interface DefaultDuty extends Omit<Duty, 'startDate' | 'endDate'> {
-  startDate?: '' | DateString;
-  endDate?: '' | DateString;
-}
-
-export interface DefaultCareer extends Omit<Career, 'position' | 'duties' | 'careerStartDate'> {
-  position: '';
-  duties?: DefaultDuty[];
-  careerStartDate: '' | DateString;
-}
+  startDate?: string;
+  endDate?: string;
+};

--- a/src/types/errorResponse.ts
+++ b/src/types/errorResponse.ts
@@ -1,0 +1,4 @@
+export type ResumeMeErrorResponse = {
+  code: string;
+  message: string;
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 업무경험 작성 api 연결 작업을 했습니다.
- 저희 이력서 작성 페이지가 사실상 수정 페이지와 다름이 없다고 생각해 EditResumePage, EditResumeTemplate에 붙였습니다. 이 부분은 나중에 다같이 다시 얘기해보는 게 좋을 것 같습니다!
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- **토큰**을 함께 보내야 하는데, 토큰 저장이 아직 작업이 안 돼있어서 우선은 **환경 변수**로 처리했습니다. (`VITE_TEMP_MENTEE_TOKEN`)
- 기술스택은 api 요청 전에 string을 배열로 split해서 바꿔서 갈아끼우고 있는데, 상단 프로필 쪽에서도 쓰이는 거라 util 정도로 따로 빼서 재사용하도록 나중에 수정하는 것도 좋을 것 같습니다.
- 스토리북에서 react router, tanstack query를 못 읽어서 스토리북 addon 등 기타 설정들을 추가했습니다.
## 🔎 PR포인트 및 궁금한 점
