### PR TITLE
Gmmq 314 hotfix: 이력서 작성 버튼, 로그인 라우팅 처리

### DIFF
--- a/src/api/resume/create/postCreateResume.ts
+++ b/src/api/resume/create/postCreateResume.ts
@@ -5,9 +5,17 @@ import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
 export const postCreateResume = async () => {
   try {
-    const { data } = await resumeMeAxios.post(`/v1/resumes`, {
-      title: CONSTANTS.RESUME_DEFAULT_TITLE,
-    });
+    const { data } = await resumeMeAxios.post(
+      `/v1/resumes`,
+      {
+        title: CONSTANTS.RESUME_DEFAULT_TITLE,
+      },
+      {
+        headers: {
+          access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+        },
+      },
+    );
     return data;
   } catch (e) {
     if (isAxiosError<ResumeMeErrorResponse>(e)) {

--- a/src/api/resume/create/postCreateResume.ts
+++ b/src/api/resume/create/postCreateResume.ts
@@ -1,0 +1,17 @@
+import { isAxiosError } from 'axios';
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+
+export const postCreateResume = async () => {
+  try {
+    const { data } = await resumeMeAxios.post(`/v1/resumes`, {
+      title: CONSTANTS.RESUME_DEFAULT_TITLE,
+    });
+    return data;
+  } catch (e) {
+    if (isAxiosError<ResumeMeErrorResponse>(e)) {
+      throw new Error(e.response?.data.message);
+    }
+  }
+};

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -1,6 +1,7 @@
 import { BellIcon } from '@chakra-ui/icons';
 import { Box, Flex, Button, Stack, Heading } from '@chakra-ui/react';
 import { Link } from 'react-router-dom';
+import { appPaths } from '~/config/paths';
 
 type NavItem = {
   label: string;
@@ -130,7 +131,7 @@ const Header = () => {
               bg: 'gray.200',
             }}
           >
-            {TEXT_CONTENTS.SIGN}
+            <Link to={appPaths.signIn}>{TEXT_CONTENTS.SIGN}</Link>
           </Button>
           <Button
             w={'30px'}

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,0 +1,3 @@
+export const appPaths = {
+  signIn: '/sign-in',
+};

--- a/src/constants/environments.ts
+++ b/src/constants/environments.ts
@@ -1,5 +1,0 @@
-const { VITE_BASE_URL } = import.meta.env;
-
-export const ENVIRONMENTS = {
-  BASE_URL_ENV: VITE_BASE_URL,
-};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,6 @@
-import { ENVIRONMENTS } from './environments';
-
 const CONSTANTS = {
-  ENVIRONMENTS,
   SIGN_UP_CACHE_KEY: 'sign-up-cache-key',
+  RESUME_DEFAULT_TITLE: '새 이력서',
 };
 
 export default CONSTANTS;

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,5 +1,22 @@
+import { Button } from '~/components/atoms/Button';
+import { usePostCreateResume } from '~/queries/resume/create/usePostCreateResume';
+
 const MainPage = () => {
-  return <></>;
+  const resumeCreateMutation = usePostCreateResume();
+  const handleResumeCreate = () => {
+    resumeCreateMutation.mutate();
+  };
+  return (
+    <>
+      {/**FIXME - 아래는 임시 이력서 작성 버튼, 추후 대체할 것 */}
+      <Button
+        size={'md'}
+        onClick={handleResumeCreate}
+      >
+        새 이력서 작성
+      </Button>
+    </>
+  );
 };
 
 export default MainPage;

--- a/src/queries/resume/create/usePostCreateResume.ts
+++ b/src/queries/resume/create/usePostCreateResume.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { postCreateResume } from '~/api/resume/create/postCreateResume';
+
+export const usePostCreateResume = () => {
+  return useMutation({
+    mutationKey: ['postResume'],
+    mutationFn: postCreateResume,
+  });
+};

--- a/src/queries/resume/create/usePostCreateResume.ts
+++ b/src/queries/resume/create/usePostCreateResume.ts
@@ -1,9 +1,14 @@
 import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
 import { postCreateResume } from '~/api/resume/create/postCreateResume';
 
 export const usePostCreateResume = () => {
+  const navigate = useNavigate();
   return useMutation({
     mutationKey: ['postResume'],
     mutationFn: postCreateResume,
+    onSuccess: ({ id }) => {
+      navigate(`/resume/${id}/edit`);
+    },
   });
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="943" alt="스크린샷 2023-11-05 오후 5 15 22" src="https://github.com/resumeme/Frontend/assets/91667853/8fd7f29c-591b-4f22-88f8-d0411e3b80ce">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 작성을 테스트해볼 수 있도록 메인 페이지에 임시로 버튼을 바로 박았습니다.
- 이력서 작성 api 연결했습니다.
  - 디폴트 제목을 constants에 '새 이력서'라고 작성해뒀습니다.
  - 작성 api 요청 성공 시 id를 받아와서 해당 이력서 작성 페이지로 이동시킵니다.

- 헤더의 로그인 버튼에 로그인 페이지로 라우팅 처리를 해두었습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
