### PR TITLE
Gmmq 300 feat: 업무경험 상세 컴포넌트 개발

### DIFF
--- a/src/api/resume/details/getResumeCareer.ts
+++ b/src/api/resume/details/getResumeCareer.ts
@@ -1,0 +1,21 @@
+import { isAxiosError } from 'axios';
+import { resumeMeAxios } from '~/api/axios';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+
+export type GetResumeCareer = { resumeId: string };
+
+export const getResumeCareer = async ({ resumeId }: GetResumeCareer) => {
+  try {
+    const { data } = await resumeMeAxios.get(`/v1/resume/${resumeId}/careers`, {
+      headers: {
+        /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+        access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+      },
+    });
+    return data;
+  } catch (e) {
+    if (isAxiosError<ResumeMeErrorResponse>(e)) {
+      throw new Error(e.response?.data.message);
+    }
+  }
+};

--- a/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
@@ -7,8 +7,9 @@ import { CategoryAddHeader } from '~/components/molecules/CategoryAddHeader';
 type ResumeCategoryProps = {
   categoryType: string;
   children: React.ReactNode;
+  detailsComponent: React.ReactNode;
 };
-const ResumeCategory = ({ categoryType, children }: ResumeCategoryProps) => {
+const ResumeCategory = ({ categoryType, detailsComponent, children }: ResumeCategoryProps) => {
   const [isShowForm, setIsShowForm] = useState(false);
   return (
     <div style={{ width: '960px', minHeight: '100px' }}>
@@ -22,6 +23,7 @@ const ResumeCategory = ({ categoryType, children }: ResumeCategoryProps) => {
         marginTop={'1.56rem'}
         spacing={'1rem'}
       >
+        {detailsComponent}
         {isShowForm && (
           <BorderBox
             key={uuidv4()}

--- a/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
@@ -1,0 +1,39 @@
+import { VStack } from '@chakra-ui/react';
+import { useState } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { CategoryAddHeader } from '~/components/molecules/CategoryAddHeader';
+
+type ResumeCategoryProps = {
+  categoryType: string;
+  children: React.ReactNode;
+};
+const ResumeCategory = ({ categoryType, children }: ResumeCategoryProps) => {
+  const [isShowForm, setIsShowForm] = useState(false);
+  return (
+    <div style={{ width: '960px', minHeight: '100px' }}>
+      <CategoryAddHeader
+        categoryTitle={categoryType}
+        onAddItem={() => {
+          setIsShowForm(true);
+        }}
+      />
+      <VStack
+        marginTop={'1.56rem'}
+        spacing={'1rem'}
+      >
+        {isShowForm && (
+          <BorderBox
+            key={uuidv4()}
+            w={'100%'}
+            p={'2rem'}
+          >
+            {children}
+          </BorderBox>
+        )}
+      </VStack>
+    </div>
+  );
+};
+
+export default ResumeCategory;

--- a/src/components/organisms/ResumeCategoryCareer/index.ts
+++ b/src/components/organisms/ResumeCategoryCareer/index.ts
@@ -1,1 +1,1 @@
-export { default as ResumeCategoryCareer } from './ResumeCategoryCareer';
+export { default as ResumeCategory } from './ResumeCategory';

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
+import { BorderBox } from '~/components/atoms/BorderBox';
 import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
 import Career from '~/types/career';
 
@@ -14,9 +15,9 @@ const CareerDetail = () => {
     <>
       {data?.map((company: Career) => {
         return (
-          <div key={uuidv4()}>
+          <BorderBox key={uuidv4()}>
             <div>{company.companyName}</div>
-          </div>
+          </BorderBox>
         );
       })}
     </>

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,27 +1,29 @@
-import { useParams } from 'react-router-dom';
-import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
-import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
-import Career from '~/types/career';
+// import { useParams } from 'react-router-dom';
+// import { v4 as uuidv4 } from 'uuid';
+// import { BorderBox } from '~/components/atoms/BorderBox';
+// import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
+// import Career from '~/types/career';
 
 const CareerDetail = () => {
-  const { id: resumeId } = useParams() as { id: string };
-
-  const { data } = useGetResumeCareer({ resumeId });
-  if (!data) {
-    return;
-  }
-  return (
-    <>
-      {data?.map((company: Career) => {
-        return (
-          <BorderBox key={uuidv4()}>
-            <div>{company.companyName}</div>
-          </BorderBox>
-        );
-      })}
-    </>
-  );
+  /**TODO - api 서버 오류 해결 후 주석 풀 것 */
+  // const { id: resumeId } = useParams() as { id: string };
+  // const { data } = useGetResumeCareer({ resumeId });
+  // if (!data) {
+  //   return;
+  // }
+  // return (
+  //   <>
+  //     {data?.map((company: Career) => {
+  //       return (
+  //         <BorderBox key={uuidv4()}>
+  //           <div>{company.companyName}</div>
+  //         </BorderBox>
+  //       );
+  //     })}
+  //   </>
+  // );
+  /**TODO - api 서버 오류 해결 후 삭제할 것 */
+  return <></>;
 };
 
 export default CareerDetail;

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,0 +1,26 @@
+import { useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
+import Career from '~/types/career';
+
+const CareerDetail = () => {
+  const { id: resumeId } = useParams() as { id: string };
+
+  const { data } = useGetResumeCareer({ resumeId });
+  if (!data) {
+    return;
+  }
+  return (
+    <>
+      {data?.map((company: Career) => {
+        return (
+          <div key={uuidv4()}>
+            <div>{company.companyName}</div>
+          </div>
+        );
+      })}
+    </>
+  );
+};
+
+export default CareerDetail;

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,10 +1,14 @@
 import CareerForm from '~/components/organisms/ResumeCategoryCareer/CareerForm';
 import ResumeCategory from '~/components/organisms/ResumeCategoryCareer/ResumeCategory';
+import CareerDetail from '~/components/organisms/ResumeDetails/CareerDetails';
 
 const EditResumeTemplate = () => {
   return (
     <>
-      <ResumeCategory categoryType="업무경험">
+      <ResumeCategory
+        categoryType="업무경험"
+        detailsComponent={<CareerDetail />}
+      >
         <CareerForm />
       </ResumeCategory>
     </>

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,9 +1,12 @@
-import { ResumeCategoryCareer } from '~/components/organisms/ResumeCategoryCareer';
+import CareerForm from '~/components/organisms/ResumeCategoryCareer/CareerForm';
+import ResumeCategory from '~/components/organisms/ResumeCategoryCareer/ResumeCategory';
 
 const EditResumeTemplate = () => {
   return (
     <>
-      <ResumeCategoryCareer />
+      <ResumeCategory categoryType="업무경험">
+        <CareerForm />
+      </ResumeCategory>
     </>
   );
 };

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -1,9 +1,25 @@
 import { useMutation } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
+import Career from '~/types/career';
 
 export const usePostResumeCareer = () => {
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = 'getResumeCareer';
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeCareer,
+    onMutate: async (newCareer) => {
+      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
+      const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
+      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
+      return { previousCareers };
+    },
+    onError: (err, newCareer, context) => {
+      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+    },
   });
 };

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
-import { useQueryClient } from '@tanstack/react-query';
+// import { useQueryClient } from '@tanstack/react-query';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
-import Career from '~/types/career';
+// import Career from '~/types/career';
 
 export const usePostResumeCareer = () => {
-  const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeCareer';
+  /**TODO - api 서버 오류 해결 후 주석 풀 것 */
+  // const queryClient = useQueryClient();
+  // const TARGET_QUERY_KEY = 'getResumeCareer';
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeCareer,
-    onMutate: async (newCareer) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
-      return { previousCareers };
-    },
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    onError: (err, newCareer, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
-    },
-    onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
-    },
+    //   onMutate: async (newCareer) => {
+    //     await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
+    //     const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
+    //     queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
+    //     return { previousCareers };
+    //   },
+    //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //   // @ts-ignore
+    //   onError: (err, newCareer, context) => {
+    //     queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
+    //   },
+    //   onSettled: () => {
+    //     queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+    //   },
   });
 };

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -15,6 +15,8 @@ export const usePostResumeCareer = () => {
       queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
       return { previousCareers };
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     onError: (err, newCareer, context) => {
       queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
     },

--- a/src/queries/resume/details/useGetResumeCareer.ts
+++ b/src/queries/resume/details/useGetResumeCareer.ts
@@ -1,0 +1,10 @@
+import { useQuery } from '@tanstack/react-query';
+import { GetResumeCareer, getResumeCareer } from '~/api/resume/details/getResumeCareer';
+
+export const useGetResumeCareer = ({ resumeId }: GetResumeCareer) => {
+  return useQuery({
+    queryKey: ['getResumeCareer'],
+    queryFn: () => getResumeCareer({ resumeId }),
+    enabled: !!resumeId,
+  });
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
- 서버 시간이 지나서 테스트를 아직 못한 상태입니다 !!

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 업무 경험 상세 컴포넌트를 개발했습니다.
- `CareerDetails` 에서 업무경험 get 요청을 보내 map으로 상세 내용을 렌더링합니다.
  - 데이터가 없으면 렌더링하지 않습니다.
- 업무 경험 저장을 누르면 낙관적 업데이트가 되도록 `usePostResumeCareer`에 옵션을 추가했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 원래는 헤더 + 폼까지를 `ResumeCategoryCareer`에 작성했는데, `ResumeCategory`로 리팩토링 해 다른 카테고리도 재사용할 수 있도록 바꿨습니다.
  - `EditResumeTemplate`에서 어떻게 사용하고 있는지 참고해주시면 될 것 같습니다.

## 🔎 PR포인트 및 궁금한 점
- 구조가 어색하지는 않은지 봐주세요!