### PR TITLE
Gmmq 300 feat: 업무 경험 작성 후 낙관적 업데이트, ResumeCategory 작성

### DIFF
--- a/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
@@ -23,7 +23,7 @@ const ResumeCategory = ({ categoryType, detailsComponent, children }: ResumeCate
         marginTop={'1.56rem'}
         spacing={'1rem'}
       >
-        {detailsComponent}
+        <BorderBox w={'100%'}>{detailsComponent}</BorderBox>
         {isShowForm && (
           <BorderBox
             key={uuidv4()}

--- a/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/ResumeCategory.tsx
@@ -23,7 +23,7 @@ const ResumeCategory = ({ categoryType, detailsComponent, children }: ResumeCate
         marginTop={'1.56rem'}
         spacing={'1rem'}
       >
-        <BorderBox w={'100%'}>{detailsComponent}</BorderBox>
+        {detailsComponent}
         {isShowForm && (
           <BorderBox
             key={uuidv4()}

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,13 +1,7 @@
-import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
-import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
 import Career from '~/types/career';
 
-const CareerDetails = () => {
-  const { id: resumeId } = useParams() as { id: string };
-
-  const { data } = useGetResumeCareer({ resumeId });
+const CareerDetails = ({ data }: { data: Career[] }) => {
   if (!data) {
     return;
   }
@@ -15,9 +9,9 @@ const CareerDetails = () => {
     <>
       {data?.map((company: Career) => {
         return (
-          <BorderBox key={uuidv4()}>
+          <div key={uuidv4()}>
             <div>{company.companyName}</div>
-          </BorderBox>
+          </div>
         );
       })}
     </>

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
+import { BorderBox } from '~/components/atoms/BorderBox';
 import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
 import Career from '~/types/career';
 
@@ -14,9 +15,9 @@ const CareerDetails = () => {
     <>
       {data?.map((company: Career) => {
         return (
-          <div key={uuidv4()}>
+          <BorderBox key={uuidv4()}>
             <div>{company.companyName}</div>
-          </div>
+          </BorderBox>
         );
       })}
     </>

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,29 +1,26 @@
-// import { useParams } from 'react-router-dom';
-// import { v4 as uuidv4 } from 'uuid';
-// import { BorderBox } from '~/components/atoms/BorderBox';
-// import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
-// import Career from '~/types/career';
+import { useParams } from 'react-router-dom';
+import { v4 as uuidv4 } from 'uuid';
+import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
+import Career from '~/types/career';
 
-const CareerDetail = () => {
-  /**TODO - api 서버 오류 해결 후 주석 풀 것 */
-  // const { id: resumeId } = useParams() as { id: string };
-  // const { data } = useGetResumeCareer({ resumeId });
-  // if (!data) {
-  //   return;
-  // }
-  // return (
-  //   <>
-  //     {data?.map((company: Career) => {
-  //       return (
-  //         <BorderBox key={uuidv4()}>
-  //           <div>{company.companyName}</div>
-  //         </BorderBox>
-  //       );
-  //     })}
-  //   </>
-  // );
-  /**TODO - api 서버 오류 해결 후 삭제할 것 */
-  return <></>;
+const CareerDetails = () => {
+  const { id: resumeId } = useParams() as { id: string };
+
+  const { data } = useGetResumeCareer({ resumeId });
+  if (!data) {
+    return;
+  }
+  return (
+    <>
+      {data?.map((company: Career) => {
+        return (
+          <div key={uuidv4()}>
+            <div>{company.companyName}</div>
+          </div>
+        );
+      })}
+    </>
+  );
 };
 
-export default CareerDetail;
+export default CareerDetails;

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { BorderBox } from '~/components/atoms/BorderBox';
 import Career from '~/types/career';
 
 const CareerDetails = ({ data }: { data: Career[] }) => {
@@ -9,9 +10,12 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
     <>
       {data?.map((company: Career) => {
         return (
-          <div key={uuidv4()}>
+          <BorderBox
+            key={uuidv4()}
+            w={'100%'}
+          >
             <div>{company.companyName}</div>
-          </div>
+          </BorderBox>
         );
       })}
     </>

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -5,9 +5,6 @@ import CareerDetail from '~/components/organisms/ResumeDetails/CareerDetails';
 import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
 
 const EditResumeTemplate = () => {
-  /**TODO - api 서버 오류 해결 후 주석 풀 것
-   * ResumeCategory의 detailsComponent에 상세 컴포넌트 props 전달하기
-   */
   const { id: resumeId } = useParams() as { id: string };
   const { data: careersData } = useGetResumeCareer({ resumeId });
   return (

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,13 +1,20 @@
+import { useParams } from 'react-router-dom';
 import CareerForm from '~/components/organisms/ResumeCategoryCareer/CareerForm';
 import ResumeCategory from '~/components/organisms/ResumeCategoryCareer/ResumeCategory';
 import CareerDetail from '~/components/organisms/ResumeDetails/CareerDetails';
+import { useGetResumeCareer } from '~/queries/resume/details/useGetResumeCareer';
 
 const EditResumeTemplate = () => {
+  /**TODO - api 서버 오류 해결 후 주석 풀 것
+   * ResumeCategory의 detailsComponent에 상세 컴포넌트 props 전달하기
+   */
+  const { id: resumeId } = useParams() as { id: string };
+  const { data: careersData } = useGetResumeCareer({ resumeId });
   return (
     <>
       <ResumeCategory
         categoryType="업무경험"
-        detailsComponent={<CareerDetail />}
+        detailsComponent={<CareerDetail data={careersData} />}
       >
         <CareerForm />
       </ResumeCategory>

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -1,28 +1,25 @@
 import { useMutation } from '@tanstack/react-query';
-// import { useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
-// import Career from '~/types/career';
+import Career from '~/types/career';
 
 export const usePostResumeCareer = () => {
-  /**TODO - api 서버 오류 해결 후 주석 풀 것 */
-  // const queryClient = useQueryClient();
-  // const TARGET_QUERY_KEY = 'getResumeCareer';
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = 'getResumeCareer';
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeCareer,
-    //   onMutate: async (newCareer) => {
-    //     await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-    //     const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
-    //     queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
-    //     return { previousCareers };
-    //   },
-    //   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //   // @ts-ignore
-    //   onError: (err, newCareer, context) => {
-    //     queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
-    //   },
-    //   onSettled: () => {
-    //     queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
-    //   },
+    onMutate: async (newCareer) => {
+      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
+      const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
+      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
+      return { previousCareers };
+    },
+    onError: (err, newCareer, context) => {
+      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+    },
   });
 };

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -15,6 +15,8 @@ export const usePostResumeCareer = () => {
       queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
       return { previousCareers };
     },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
     onError: (err, newCareer, context) => {
       queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
     },


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)

https://github.com/resumeme/Frontend/assets/91667853/91bf9e32-bf80-49b1-b63e-ae8693141345


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 업무경험을 저장하면 업무경험 상세 컴포넌트 `CareerDetails`에 작성한 데이터가 뿌려지도록 작성했습니다. (현재는 companyName만 뽑아서 렌더링했습니다.)
- 상세 레이아웃은 `CareerDetails`에 작성하시면 됩니다. @khakhiD 
- `ResumeCategory`의 detailsComponent에 상세 컴포넌트를 전달하고, children으로 카테고리 폼을 작성하시면 됩니다.
- 카테고리마다 상세 데이터를 불러오는 작업은 `EditResumeTemplate`에서 수행하고, 불러온 데이터를 상세 컴포넌트의 data prop으로 전달합니다. (`EditResumeTemplate` 참고!)

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 기존에 작성한 ResumeCategoryCareer는 삭제될 예정입니다! 카테고리마다 따로 만들 필요 없이 `ResumeCategory`를 사용하시면 됩니다.
- 업무경험 작성 mutation `usePostResumeCareer`에서 낙관적 업데이트를 적용했습니다. ([참고 공식 문서](https://tanstack.com/query/latest/docs/react/guides/optimistic-updates#updating-a-single-todo))

## 🔎 PR포인트 및 궁금한 점
