### PR TITLE
Gmmq 317 feat: dynamic tags (기술스택 태그 배열) 삭제 기능, 간격 스타일 수정

### DIFF
--- a/src/components/molecules/DynamicTags/DynamicTags.tsx
+++ b/src/components/molecules/DynamicTags/DynamicTags.tsx
@@ -1,32 +1,45 @@
+import { CloseIcon } from '@chakra-ui/icons';
 import { Flex, Tag } from '@chakra-ui/react';
 import { FlexProps, TagProps } from '@chakra-ui/react';
 import { v4 as uuidv4 } from 'uuid';
 
 type DynamicTagsProps = {
   tagsArray: string[];
+  handleItemDelete: (index: number) => void;
   flexProps?: FlexProps;
   tagProps?: TagProps;
 };
 
-const DynamicTags = ({ tagsArray, flexProps, tagProps }: DynamicTagsProps) => {
+const DynamicTags = ({ tagsArray, handleItemDelete, flexProps, tagProps }: DynamicTagsProps) => {
   return (
     <Flex
       gap={'0.5rem'}
       wrap={'wrap'}
       {...flexProps}
     >
-      {tagsArray.map((tag) => {
+      {tagsArray.map((tag, index) => {
         return (
           <Tag
             bg={'primary.100'}
             key={uuidv4()}
+            display={'flex'}
+            gap={3}
             {...tagProps}
           >
             {tag}
+            <DeleteButton onClick={() => handleItemDelete(index)} />
           </Tag>
         );
       })}
     </Flex>
+  );
+};
+
+const DeleteButton = ({ onClick }: { onClick: React.MouseEventHandler<HTMLButtonElement> }) => {
+  return (
+    <button onClick={onClick}>
+      <CloseIcon w={2.5} />
+    </button>
   );
 };
 

--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -29,7 +29,7 @@ const BasicInfoForm = () => {
     });
   };
 
-  const [skills, handleSkillsetChange] = useStringToArray();
+  const [skills, handleSkillsetChange, handleItemDelete] = useStringToArray();
   const introduceValue = useWatch({ name: 'introduce', control });
   const introduceValueLength = introduceValue ? introduceValue.length : 0;
 
@@ -98,7 +98,12 @@ const BasicInfoForm = () => {
                   onKeyDown={handleSkillsetChange}
                   error={errors.skillset}
                 />
-                {skills.length > 0 && <DynamicTags tagsArray={skills} />}
+                {skills.length > 0 && (
+                  <DynamicTags
+                    tagsArray={skills}
+                    handleItemDelete={handleItemDelete}
+                  />
+                )}
               </Flex>
             </FormControl>
           </Box>

--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -77,30 +77,29 @@ const BasicInfoForm = () => {
         >
           <Box>
             <FormControl isInvalid={!!errors.skillset}>
-              <FormTextInput
-                id="skillset"
-                register={{
-                  ...register('skillset', {
-                    pattern: {
-                      value: /^[a-zA-Z가-힣\s]*$/,
-                      message: '영어, 한글, 공백만 입력 가능합니다.',
-                    },
-                  }),
-                }}
-                autoComplete="off"
-                spellCheck="false"
-                placeholder="보유한 기술 스택"
-                onKeyDown={handleSkillsetChange}
-                error={errors.skillset}
-              />
-              {skills.length > 0 && (
-                <DynamicTags
-                  tagsArray={skills}
-                  flexProps={{
-                    my: 3,
+              <Flex
+                gap={2}
+                direction={'column'}
+                w={'full'}
+              >
+                <FormTextInput
+                  id="skillset"
+                  register={{
+                    ...register('skillset', {
+                      pattern: {
+                        value: /^[a-zA-Z가-힣\s]*$/,
+                        message: '영어, 한글, 공백만 입력 가능합니다.',
+                      },
+                    }),
                   }}
+                  autoComplete="off"
+                  spellCheck="false"
+                  placeholder="보유한 기술 스택"
+                  onKeyDown={handleSkillsetChange}
+                  error={errors.skillset}
                 />
-              )}
+                {skills.length > 0 && <DynamicTags tagsArray={skills} />}
+              </Flex>
             </FormControl>
           </Box>
         </Tooltip>

--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -38,8 +38,11 @@ const BasicInfoForm = () => {
   // const saveFormData = async () => {}
 
   return (
-    <Box>
-      <form onSubmit={handleSubmit(onSubmit)}>
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <Flex
+        gap={3}
+        direction={'column'}
+      >
         <Tooltip
           hasArrow
           placement="right"
@@ -47,7 +50,6 @@ const BasicInfoForm = () => {
           aria-label="tooltip"
           borderRadius={'xl'}
           fontSize={'sm'}
-          px={3}
           bg={'gray.300'}
           color={'gray.600'}
         >
@@ -59,7 +61,6 @@ const BasicInfoForm = () => {
                 placeholder="희망 직무"
                 autoComplete="off"
                 spellCheck="false"
-                mb={3}
               />
             </FormControl>
           </Box>
@@ -71,7 +72,6 @@ const BasicInfoForm = () => {
           aria-label="tooltip"
           borderRadius={'xl'}
           fontSize={'sm'}
-          px={3}
           bg={'gray.300'}
           color={'gray.600'}
         >
@@ -93,54 +93,58 @@ const BasicInfoForm = () => {
                 onKeyDown={handleSkillsetChange}
                 error={errors.skillset}
               />
+              {skills.length > 0 && (
+                <DynamicTags
+                  tagsArray={skills}
+                  flexProps={{
+                    my: 3,
+                  }}
+                />
+              )}
             </FormControl>
-            <DynamicTags
-              tagsArray={skills}
-              flexProps={{
-                my: 3,
-              }}
-            />
           </Box>
         </Tooltip>
-        <FormControl isInvalid={Boolean(errors.introduce)}>
-          <FormTextarea
-            id="introduce"
-            name="introduce"
-            register={{
-              ...register('introduce', {
-                required: false,
-                maxLength: {
-                  value: 100,
-                  message: `100자 이내로 입력해주세요. (${introduceValueLength}자)`,
-                },
-              }),
-            }}
-            errors={errors}
-            height="100px"
-            width="full"
-            placeholder="간략한 자기소개 (100자 이내)"
-            resize="none"
-            autoComplete="off"
-            spellCheck="false"
-          />
-        </FormControl>
-        {introduceValue && (
-          <Box
-            textAlign={'right'}
-            display={introduceValueLength <= 100 ? 'block' : 'none'}
-            pr={2}
-            m={0}
-            zIndex="docked"
-          >
-            <Text
-              as="span"
-              fontSize="xs"
-              color={introduceValueLength <= 100 ? 'gray.800' : 'red'}
+        <Box>
+          <FormControl isInvalid={Boolean(errors.introduce)}>
+            <FormTextarea
+              id="introduce"
+              name="introduce"
+              register={{
+                ...register('introduce', {
+                  required: false,
+                  maxLength: {
+                    value: 100,
+                    message: `100자 이내로 입력해주세요. (${introduceValueLength}자)`,
+                  },
+                }),
+              }}
+              errors={errors}
+              height="100px"
+              width="full"
+              placeholder="간략한 자기소개 (100자 이내)"
+              resize="none"
+              autoComplete="off"
+              spellCheck="false"
+            />
+          </FormControl>
+          {introduceValue && (
+            <Box
+              textAlign={'right'}
+              display={introduceValueLength <= 100 ? 'block' : 'none'}
+              pr={2}
+              m={0}
+              zIndex="docked"
             >
-              {introduceValueLength}/100
-            </Text>
-          </Box>
-        )}
+              <Text
+                as="span"
+                fontSize="xs"
+                color={introduceValueLength <= 100 ? 'gray.800' : 'red'}
+              >
+                {introduceValueLength}/100
+              </Text>
+            </Box>
+          )}
+        </Box>
         <Flex
           justify={'flex-end'}
           mt={3}
@@ -152,8 +156,8 @@ const BasicInfoForm = () => {
             저장
           </Button>
         </Flex>
-      </form>
-    </Box>
+      </Flex>
+    </form>
   );
 };
 

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -113,13 +113,19 @@ const CareerForm = () => {
         </FormControl>
         <FormControl>
           <FormLabel>사용 스택</FormLabel>
-          <FormTextInput
-            id="skills"
-            register={{ ...register('skills') }}
-            onKeyDown={handleArrayChange}
-          />
+          <Flex
+            gap={2}
+            direction={'column'}
+            w={'full'}
+          >
+            <FormTextInput
+              id="skills"
+              register={{ ...register('skills') }}
+              onKeyDown={handleArrayChange}
+            />
+            {skills.length > 0 && <DynamicTags tagsArray={skills} />}
+          </Flex>
         </FormControl>
-        {skills.length > 0 && <DynamicTags tagsArray={skills} />}
         <FormControl>
           <FormLabel>기타 설명</FormLabel>
           <FormTextInput

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -45,7 +45,7 @@ const CareerForm = () => {
   const { id: resumeId } = useParams();
   const { mutate } = usePostResumeCareer();
   const navigate = useNavigate();
-  const [skills, handleArrayChange] = useStringToArray();
+  const [skills, handleArrayChange, handleItemDelete] = useStringToArray();
   const onSubmit = handleSubmit((resumeCareer) => {
     if (!resumeId) {
       /**TODO - 토스트 대체! */
@@ -123,7 +123,12 @@ const CareerForm = () => {
               register={{ ...register('skills') }}
               onKeyDown={handleArrayChange}
             />
-            {skills.length > 0 && <DynamicTags tagsArray={skills} />}
+            {skills.length > 0 && (
+              <DynamicTags
+                tagsArray={skills}
+                handleItemDelete={handleItemDelete}
+              />
+            )}
           </Flex>
         </FormControl>
         <FormControl>

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -119,7 +119,7 @@ const CareerForm = () => {
             onKeyDown={handleArrayChange}
           />
         </FormControl>
-        <DynamicTags tagsArray={skills} />
+        {skills.length > 0 && <DynamicTags tagsArray={skills} />}
         <FormControl>
           <FormLabel>기타 설명</FormLabel>
           <FormTextInput

--- a/src/hooks/useStringToArray.tsx
+++ b/src/hooks/useStringToArray.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 export const useStringToArray = (): [
   string[],
   (event: React.KeyboardEvent<HTMLInputElement>) => void,
+  (targetIndex: number) => void,
 ] => {
   const [array, setSkills] = useState<string[]>([]);
 
@@ -17,11 +18,17 @@ export const useStringToArray = (): [
     if (!skill.trim() || skill === ',') {
       event.currentTarget.value = '';
     }
-    if (skill.length > 2 && key === 'Enter') {
+    if (skill.length > 1 && key === 'Enter') {
       setSkills([...array, skill]);
       event.currentTarget.value = '';
     }
   };
 
-  return [array, handleArrayChange];
+  const handleItemDelete = (targetIndex: number) => {
+    const newArray = [...array];
+    newArray.splice(targetIndex, 1);
+    setSkills(newArray);
+  };
+
+  return [array, handleArrayChange, handleItemDelete];
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

https://github.com/resumeme/Frontend/assets/91667853/9e19e134-93e4-4c34-964c-db59be3d8d07


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- DynamicTags에서 태그 삭제 기능을 추가했습니다.
- 지호님이 작성하신 useStringToArray에 handleItemDelete 함수 하나를 추가해서, 훅 사용하실 때 이걸 추가로 빼내시고, DynamicTags의 props로 전달하면 됩니다.


## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

- 추가로 DynamicTags의 간격 문제를 수정했습니다.
- 사용하는 쪽에서 간격을 설정하는 게 낫다고 생각해서 DynamicTags 자체에는 margin등을 주지 않았습니다.

## 🔎 PR포인트 및 궁금한 점
