### PR TITLE
Gmmq 320 feat: mentor block api 연결 작업

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,4 +1,6 @@
 import type { Preview } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
 import { withRouter } from 'storybook-addon-react-router-v6';
 import theme from '../src/theme';
 
@@ -15,7 +17,18 @@ const preview: Preview = {
       theme,
     },
   },
-  decorators: [withRouter],
+  decorators: [
+    withRouter,
+    (Story) => {
+      const queryClient = new QueryClient();
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
 };
 
 export default preview;

--- a/src/api/user/getMentorDetail.ts
+++ b/src/api/user/getMentorDetail.ts
@@ -1,0 +1,23 @@
+import { isAxiosError } from 'axios';
+import { resumeMeAxios } from '~/api/axios';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+import { ReadMentor } from '~/types/mentor';
+
+export type GetMentorDetail = { mentorId?: string };
+
+export const getMentorDetail = async ({ mentorId }: GetMentorDetail): Promise<ReadMentor> => {
+  try {
+    const { data } = await resumeMeAxios.get(`/v1/mentors/${mentorId}`, {
+      headers: {
+        /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+        access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+      },
+    });
+    return data;
+  } catch (e) {
+    if (isAxiosError<ResumeMeErrorResponse>(e)) {
+      throw new Error(e.response?.data.message);
+    }
+    return {} as ReadMentor;
+  }
+};

--- a/src/api/user/getMentorDetail.ts
+++ b/src/api/user/getMentorDetail.ts
@@ -7,7 +7,7 @@ export const getMentorDetail = async ({ mentorId }: GetMentorDetail): Promise<Re
   const { data } = await resumeMeAxios.get(`/v1/mentors/${mentorId}`, {
     headers: {
       /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-      access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+      Authorization: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
     },
   });
   return data;

--- a/src/api/user/getMentorDetail.ts
+++ b/src/api/user/getMentorDetail.ts
@@ -1,23 +1,14 @@
-import { isAxiosError } from 'axios';
 import { resumeMeAxios } from '~/api/axios';
-import { ResumeMeErrorResponse } from '~/types/errorResponse';
 import { ReadMentor } from '~/types/mentor';
 
 export type GetMentorDetail = { mentorId?: string };
 
 export const getMentorDetail = async ({ mentorId }: GetMentorDetail): Promise<ReadMentor> => {
-  try {
-    const { data } = await resumeMeAxios.get(`/v1/mentors/${mentorId}`, {
-      headers: {
-        /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-        access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
-      },
-    });
-    return data;
-  } catch (e) {
-    if (isAxiosError<ResumeMeErrorResponse>(e)) {
-      throw new Error(e.response?.data.message);
-    }
-    return {} as ReadMentor;
-  }
+  const { data } = await resumeMeAxios.get(`/v1/mentors/${mentorId}`, {
+    headers: {
+      /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+      access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+    },
+  });
+  return data;
 };

--- a/src/components/molecules/MentorProfile/index.stories.tsx
+++ b/src/components/molecules/MentorProfile/index.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta } from '@storybook/react';
+import { MentorProfile } from '.';
+import { Position } from '~/types/position';
+
+const meta = {
+  title: 'Resumeme/Components/MentorProfile',
+  component: MentorProfile,
+  tags: ['autodocs'],
+} satisfies Meta<typeof MentorProfile>;
+
+export default meta;
+
+export const Default = () => {
+  const DUMMY_DATA = {
+    mentor: {
+      imageUrl: 'image.png',
+      nickname: 'nickname',
+      role: 'ROLE_PENDING',
+      experiencedPositions: ['FRONT', 'BACK'] as Position[],
+      careerContent: '안녕하세요 멘토가 되고싶어요.',
+      careerYear: 3,
+      introduce:
+        '안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자! 안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!',
+    },
+    event: {
+      info: {
+        title: 'title',
+        content: 'content',
+        maximumAttendee: 3,
+      },
+      time: {
+        openDateTime: '2023-10-23T12:00:00',
+        closeDateTime: '2023-10-24T12:00:00',
+        endDate: '2023-10-30T23:00:00',
+      },
+      positions: ['FRONT', 'BACK'],
+      resumes: [
+        {
+          resumeId: 1,
+          menteeName: '백둥둥',
+          resumeTitle: 'title',
+          progressStatus: 'APPLY',
+        },
+        {
+          resumeId: 4,
+          menteeName: '백둥둥2',
+          resumeTitle: 'title',
+          progressStatus: 'APPLY',
+        },
+      ],
+      applicantCount: 3,
+    },
+  };
+  return (
+    <MentorProfile
+      mentor={DUMMY_DATA.mentor}
+      event={DUMMY_DATA.event}
+    />
+  );
+};

--- a/src/components/molecules/MentorProfile/index.ts
+++ b/src/components/molecules/MentorProfile/index.ts
@@ -1,0 +1,3 @@
+import MentorProfile from './MentorProfile';
+
+export { MentorProfile };

--- a/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
@@ -1,17 +1,7 @@
 import MentorProfile from '~/components/molecules/MentorProfile/MentorProfile';
-import { Position } from '~/types/position';
+import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const DUMMY_DATA = {
-  mentor: {
-    imageUrl: 'image.png',
-    nickname: 'nickname',
-    role: 'ROLE_PENDING',
-    experiencedPositions: ['FRONT', 'BACK'] as Position[],
-    careerContent: '안녕하세요 멘토가 되고싶어요.',
-    careerYear: 3,
-    introduce:
-      '안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자! 안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!안녕하시렵니까? 큰돌입니다. 10년차 프론트앤드 개발자!',
-  },
   event: {
     info: {
       title: 'title',
@@ -43,9 +33,11 @@ const DUMMY_DATA = {
 };
 
 const EventDetailPage = () => {
+  const { data: mentor } = useGetMentorDetail({ mentorId: '1' });
+
   return (
     <MentorProfile
-      mentor={DUMMY_DATA.mentor}
+      mentor={mentor}
       event={DUMMY_DATA.event}
     />
   );

--- a/src/queries/user/details/useGetMentorDetail.tsx
+++ b/src/queries/user/details/useGetMentorDetail.tsx
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { GetMentorDetail, getMentorDetail } from '~/api/user/getMentorDetail';
+
+export const useGetMentorDetail = ({ mentorId }: GetMentorDetail) => {
+  return useSuspenseQuery({
+    queryKey: ['getMentorDetail'],
+    queryFn: () => getMentorDetail({ mentorId }),
+  });
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -39,7 +39,7 @@ const router = createBrowserRouter([
 
       { path: 'event/create', element: <CreateEventPage /> },
       { path: 'event/view', element: <EventListPage /> },
-      { path: 'event/view/:eventId', element: <EventDetailPage /> },
+      { path: 'event/view/:id', element: <EventDetailPage /> },
       { path: 'event/apply', element: <ApplyEventPage /> },
 
       { path: 'sign-up/common', element: <CommonSignUpPage /> },


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
멘토 정보 컴포넌트의 멘토 부분을 작업했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
이전 커밋들과 내용이 합쳐져서 밑에 적혀있는 **파일만 확인**하시면 됩니다!
src\api\user\getMentorDetail.ts
src\queries\user\details\useGetMentorDetail.tsx
src\routes\router.tsx
src\pages\EventPages\EventDetailPage\EventDetailPage.tsx

**useSuspenseQuery**를 사용해서 받아오는 값이 undefined를 포함하지 않도록 했습니다.
데이터를 받아오는 곳에서 분기처리(undefined검사)를 따로 하지 않기 위해 사용했습니다.
정보는 [관련 글](https://tanstack.com/query/v5/docs/react/guides/suspense)을 읽어보시면 될 것 같습니다.

멘토 정보를 받아오는 **함수의 반환 타입**을 지정했습니다. useSuspenseQuery 또는 useQuery를 사용하여 데이터를 받아오는 곳에서 any 타입이 되는 것 같아서 설정했습니다.
```tsx
const getMentorDetail = async ({ mentorId }: GetMentorDetail): Promise<ReadMentor> => {
```

멘토 정보를 받아오는 함수에서 **try-catch**를 사용하지 않았습니다.
suspensequery를 사용해서 error를 발생시키는 것 같습니다.

## 🔎 PR포인트 및 궁금한 점