### PR TITLE
Gmmq 279 fix: LabelCheckBox에서 ref에 관련된 오류를 수정

### DIFF
--- a/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
+++ b/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
@@ -48,10 +48,11 @@ const LabelCheckboxGroup = <T extends FieldValues>({
       <Controller
         name={name}
         control={control}
-        render={({ field }) => (
+        render={({ field: { onChange, value } }) => (
           <CheckboxGroup
             {...props}
-            {...field}
+            onChange={onChange}
+            value={value}
           >
             <Stack
               spacing={spacing}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/408a1dbf-cb80-4d84-b65b-6e082fb651e6)

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
LabelCheckBox에서 ref에 관련된 오류를 수정했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
chakra-ui에 있는 컴포넌트 들은 알아서 forwardref가 내장되어있다고 하는데 checkbox와 같은 몇몇 컴포넌트 들에는 없다고 합니다.
ref를 넣어놓지 않은 컴포넌트에 굳이 또 ref를 부여할 필요는 없다고 생각해서 OnChange, value에 대항하는 props만 전달하는 것으로 수정했습니다
```tsx
render={({ field: { onChange, value } }) => (
  <CheckboxGroup
    {...props}
    onChange={onChange}
    value={value}
  >
``` 

## 🔎 PR포인트 및 궁금한 점
