### PR TITLE
Gmmq 288 feat: 이력서 제목 자동저장 기능 구현

### DIFF
--- a/src/api/resume/create/patchResumeTitle.ts
+++ b/src/api/resume/create/patchResumeTitle.ts
@@ -14,7 +14,7 @@ export const patchResumeTitle = async ({ resumeId, resumeTitle }: patchResumeTit
       {
         headers: {
           /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-          access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+          Authorization: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
         },
       },
     );

--- a/src/api/resume/create/patchResumeTitle.ts
+++ b/src/api/resume/create/patchResumeTitle.ts
@@ -2,14 +2,11 @@ import { isAxiosError } from 'axios';
 import { resumeMeAxios } from '~/api/axios';
 import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
-type postResumeTitle = { resumeId: string; resumeTitle: string };
+type patchResumeTitle = { resumeId: string; resumeTitle: string };
 
-/* TODO 이력서 제목 수정 api가 필요! */
-const api주소 = '';
-
-export const postResumeTitle = async ({ resumeId, resumeTitle }: postResumeTitle) => {
+export const patchResumeTitle = async ({ resumeId, resumeTitle }: patchResumeTitle) => {
   try {
-    const { data } = await resumeMeAxios.post(`v1/resume/${resumeId}/${api주소}`, resumeTitle, {
+    const { data } = await resumeMeAxios.post(`v1/resume/${resumeId}/title`, resumeTitle, {
       headers: {
         /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
         access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,

--- a/src/api/resume/create/patchResumeTitle.ts
+++ b/src/api/resume/create/patchResumeTitle.ts
@@ -6,12 +6,18 @@ type patchResumeTitle = { resumeId: string; resumeTitle: string };
 
 export const patchResumeTitle = async ({ resumeId, resumeTitle }: patchResumeTitle) => {
   try {
-    const { data } = await resumeMeAxios.patch(`v1/resume/${resumeId}/title`, resumeTitle, {
-      headers: {
-        /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-        access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+    const { data } = await resumeMeAxios.patch(
+      `v1/resumes/${resumeId}/title`,
+      {
+        title: resumeTitle,
       },
-    });
+      {
+        headers: {
+          /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+          access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+        },
+      },
+    );
     return data;
   } catch (e) {
     if (isAxiosError<ResumeMeErrorResponse>(e)) {

--- a/src/api/resume/create/patchResumeTitle.ts
+++ b/src/api/resume/create/patchResumeTitle.ts
@@ -6,7 +6,7 @@ type patchResumeTitle = { resumeId: string; resumeTitle: string };
 
 export const patchResumeTitle = async ({ resumeId, resumeTitle }: patchResumeTitle) => {
   try {
-    const { data } = await resumeMeAxios.post(`v1/resume/${resumeId}/title`, resumeTitle, {
+    const { data } = await resumeMeAxios.patch(`v1/resume/${resumeId}/title`, resumeTitle, {
       headers: {
         /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
         access: import.meta.env.VITE_TEMP_MENTEE_TOKEN,

--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -3,8 +3,8 @@ import { ReactNode } from 'react';
 import { FieldError, FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
 
 type TitleInputProps = {
-  id: string;
-  register: UseFormRegisterReturn;
+  id?: string;
+  register?: UseFormRegisterReturn;
   error?: FieldError | FieldErrors;
   children?: ReactNode;
 } & Omit<InputProps, 'type'>;

--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -2,7 +2,7 @@ import { Input, InputProps, FormErrorMessage, Flex } from '@chakra-ui/react';
 import { ReactNode } from 'react';
 import { FieldError, FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
 
-type TitleInputProps = InputProps & {
+type TitleInputProps = {
   id: string;
   register: UseFormRegisterReturn;
   error?: FieldError | FieldErrors;
@@ -29,7 +29,7 @@ const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps
         borderColor={'gray.300'}
         placeholder="이력서 제목"
         _placeholder={{ color: 'gray.400', fontWeight: 'semibold' }}
-        fontSize={'32px'}
+        fontSize={'2rem'}
         px={2}
         {...register}
         {...props}

--- a/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
@@ -1,5 +1,4 @@
 import { Box, Flex, Spinner, Tooltip } from '@chakra-ui/react';
-import { IconType } from 'react-icons';
 import { HiCheck, HiXCircle } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 import TitleInput from '~/components/atoms/TitleInput/TitleInput';
@@ -28,7 +27,6 @@ const StateTooltip = (state: 'success' | 'error') => {
     <Tooltip
       shouldWrapChildren
       hasArrow
-      // defaultIsOpen
       placement="top-end"
       label={STATE_STYLE[state].message}
       aria-label="tooltip"
@@ -45,30 +43,6 @@ const StateTooltip = (state: 'success' | 'error') => {
     </Tooltip>
   );
 };
-
-// const ErrorTooltip = () => {
-//   const errorIcon = renderIcon(HiXCircle, 'xl', {
-//     color: 'red.600',
-//   });
-
-//   return (
-//     <Tooltip
-//       shouldWrapChildren
-//       hasArrow
-//       // defaultIsOpen
-//       placement="top-end"
-//       label={`저장에 실패했습니다!`}
-//       aria-label="tooltip"
-//       borderRadius={'xl'}
-//       fontSize={'sm'}
-//       px={3}
-//       bg={'red.600'}
-//       color={'gray.100'}
-//     >
-//       {errorIcon}
-//     </Tooltip>
-//   );
-// };
 
 const TitleInputForm = () => {
   const { id: resumeId } = useParams();
@@ -91,12 +65,12 @@ const TitleInputForm = () => {
     debounceTimeout = setTimeout(() => {
       const resumeTitle = e.target.value;
       mutate({ resumeId, resumeTitle });
-    }, 500);
+    }, 1000);
   };
 
   const renderMutationState = () => {
     if (isPending) {
-      console.log('pending');
+      /* TODO pending 상태일 때, Spinner가 돌아가는 최소 시간을 보장하는 로직을 추가해보자 */
       return (
         <Spinner
           thickness="2px"
@@ -108,11 +82,9 @@ const TitleInputForm = () => {
       );
     }
     if (isError) {
-      console.log('error');
       return StateTooltip('error');
     }
     if (isSuccess) {
-      console.log('success');
       return StateTooltip('success');
     }
     return null;

--- a/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
@@ -1,9 +1,74 @@
-import { Box, Flex, Spinner } from '@chakra-ui/react';
+import { Box, Flex, Spinner, Tooltip } from '@chakra-ui/react';
+import { IconType } from 'react-icons';
 import { HiCheck, HiXCircle } from 'react-icons/hi';
 import { useNavigate, useParams } from 'react-router-dom';
 import TitleInput from '~/components/atoms/TitleInput/TitleInput';
 import { renderIcon } from '~/components/molecules/ReferenceLinkBox';
 import { usePatchResumeTitle } from '~/queries/resume/create/usePatchResumeTitle';
+
+const StateTooltip = (state: 'success' | 'error') => {
+  const STATE_STYLE = {
+    success: {
+      icon: HiCheck,
+      color: 'primary.900',
+      message: '저장되었어요 :)',
+    },
+    error: {
+      icon: HiXCircle,
+      color: 'red.600',
+      message: '저장에 실패했어요 :(',
+    },
+  };
+
+  const stateIcon = renderIcon(STATE_STYLE[state].icon, 'xl', {
+    color: STATE_STYLE[state].color,
+  });
+
+  return (
+    <Tooltip
+      shouldWrapChildren
+      hasArrow
+      // defaultIsOpen
+      placement="top-end"
+      label={STATE_STYLE[state].message}
+      aria-label="tooltip"
+      borderRadius={'xl'}
+      fontSize={'sm'}
+      px={3}
+      bg={STATE_STYLE[state].color}
+      color={'gray.100'}
+      display={'flex'}
+      justifyContent={'center'}
+      alignItems={'center'}
+    >
+      {stateIcon}
+    </Tooltip>
+  );
+};
+
+// const ErrorTooltip = () => {
+//   const errorIcon = renderIcon(HiXCircle, 'xl', {
+//     color: 'red.600',
+//   });
+
+//   return (
+//     <Tooltip
+//       shouldWrapChildren
+//       hasArrow
+//       // defaultIsOpen
+//       placement="top-end"
+//       label={`저장에 실패했습니다!`}
+//       aria-label="tooltip"
+//       borderRadius={'xl'}
+//       fontSize={'sm'}
+//       px={3}
+//       bg={'red.600'}
+//       color={'gray.100'}
+//     >
+//       {errorIcon}
+//     </Tooltip>
+//   );
+// };
 
 const TitleInputForm = () => {
   const { id: resumeId } = useParams();
@@ -31,6 +96,7 @@ const TitleInputForm = () => {
 
   const renderMutationState = () => {
     if (isPending) {
+      console.log('pending');
       return (
         <Spinner
           thickness="2px"
@@ -42,16 +108,12 @@ const TitleInputForm = () => {
       );
     }
     if (isError) {
-      const errorIcon = renderIcon(HiXCircle, 'xl', {
-        color: 'red.600',
-      });
-      return errorIcon;
+      console.log('error');
+      return StateTooltip('error');
     }
     if (isSuccess) {
-      const successIcon = renderIcon(HiCheck, 'xl', {
-        color: 'primary.900',
-      });
-      return successIcon;
+      console.log('success');
+      return StateTooltip('success');
     }
     return null;
   };

--- a/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
@@ -1,38 +1,92 @@
-import { Box } from '@chakra-ui/react';
-import { useForm } from 'react-hook-form';
+import { Box, Flex, Spinner } from '@chakra-ui/react';
+import { HiCheck, HiXCircle } from 'react-icons/hi';
+import { useNavigate, useParams } from 'react-router-dom';
 import TitleInput from '~/components/atoms/TitleInput/TitleInput';
+import { renderIcon } from '~/components/molecules/ReferenceLinkBox';
+import { usePatchResumeTitle } from '~/queries/resume/create/usePatchResumeTitle';
 
 const TitleInputForm = () => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors },
-  } = useForm();
+  const { id: resumeId } = useParams();
+  const { mutate, isPending, isSuccess, isError } = usePatchResumeTitle();
+  const navigate = useNavigate();
 
-  const onSubmit = handleSubmit((values) => {
-    /* TODO api 요청으로 기본 정보 저장하기 */
-    console.log('values', values);
-  });
+  let debounceTimeout: NodeJS.Timeout | null = null;
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (!resumeId) {
+      alert('존재하지 않는 이력서입니다.');
+      navigate(-1);
+      return;
+    }
+
+    if (debounceTimeout) {
+      clearTimeout(debounceTimeout);
+    }
+
+    debounceTimeout = setTimeout(() => {
+      const resumeTitle = e.target.value;
+      mutate({ resumeId, resumeTitle });
+    }, 500);
+  };
+
+  const renderMutationState = () => {
+    if (isPending) {
+      return (
+        <Spinner
+          thickness="2px"
+          speed="0.7s"
+          emptyColor="gray.300"
+          color="primary.700"
+          size="sm"
+        />
+      );
+    }
+    if (isError) {
+      const errorIcon = renderIcon(HiXCircle, 'xl', {
+        color: 'red.600',
+      });
+      return errorIcon;
+    }
+    if (isSuccess) {
+      const successIcon = renderIcon(HiCheck, 'xl', {
+        color: 'primary.900',
+      });
+      return successIcon;
+    }
+    return null;
+  };
 
   return (
-    <Box
+    <Flex
       w={'full'}
+      justify={'center'}
+      align={'center'}
+      position={'relative'}
       mb={10}
     >
-      <form onSubmit={onSubmit}>
-        <TitleInput
-          id="resumeTitle"
-          register={{
-            ...register('resumeTitle'),
-          }}
-          error={errors.resumeTitle}
-          fontWeight={'semibold'}
-          fontSize={'3xl'}
-          autoComplete="off"
-          spellCheck="false"
-        />
-      </form>
-    </Box>
+      <TitleInput
+        id="resumeTitle"
+        position={'relative'}
+        fontWeight={'semibold'}
+        fontSize={'3xl'}
+        autoComplete="off"
+        spellCheck="false"
+        onChange={handleInputChange}
+        _focusVisible={{
+          borderBottomColor: `${isError ? 'red' : 'primary.900'}`,
+        }}
+      />
+      <Box
+        className="box"
+        position={'absolute'}
+        right={'0px'}
+        display={'flex'}
+        alignItems={'center'}
+        justifyContent={'center'}
+      >
+        {renderMutationState()}
+      </Box>
+    </Flex>
   );
 };
 

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react';
+
+export const useDebounce = <T>(value: T, delay: number): T => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};

--- a/src/queries/resume/create/usePatchResumeTitle.ts
+++ b/src/queries/resume/create/usePatchResumeTitle.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import { patchResumeTitle } from '~/api/resume/create/patchResumeTitle';
+
+export const usePatchResumeTitle = () => {
+  return useMutation({
+    mutationKey: ['postTitle'],
+    mutationFn: patchResumeTitle,
+  });
+};

--- a/src/queries/resume/create/usePatchResumeTitle.ts
+++ b/src/queries/resume/create/usePatchResumeTitle.ts
@@ -2,8 +2,10 @@ import { useMutation } from '@tanstack/react-query';
 import { patchResumeTitle } from '~/api/resume/create/patchResumeTitle';
 
 export const usePatchResumeTitle = () => {
-  return useMutation({
-    mutationKey: ['postTitle'],
+  const { mutate, isPending, isError, isSuccess } = useMutation({
+    mutationKey: ['patchTitle'],
     mutationFn: patchResumeTitle,
   });
+
+  return { mutate, isPending, isError, isSuccess };
 };

--- a/src/queries/resume/create/usePostResumeTitle.ts
+++ b/src/queries/resume/create/usePostResumeTitle.ts
@@ -1,9 +1,0 @@
-import { useMutation } from '@tanstack/react-query';
-import { postResumeTitle } from '~/api/resume/create/postResumeTitle';
-
-export const usePostResumeTitle = () => {
-  return useMutation({
-    mutationKey: ['postTitle'],
-    mutationFn: postResumeTitle,
-  });
-};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

![autosave-screenshot](https://github.com/resumeme/Frontend/assets/74141521/7a018339-5e14-4c5b-bbcd-86e1e5291cc4)

[이미지링크](https://github.com/resumeme/Frontend/assets/74141521/7a018339-5e14-4c5b-bbcd-86e1e5291cc4)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 제목 인풋에 1초의 디바운스를 걸어 자동으로 저장하도록 구현했습니다.
  - 사용자가 입력을 멈추고 수정 사항이 발견되면 0.5초 이후에 submit이 진행됩니다.
  - `isPending`, `isSuccess`, `isError` 뮤테이션 상태에 따라서 Input 오른쪽의 **아이콘 UI와 툴팁으로 상태 확인이 가능**합니다.
- **자동 저장 테스트 완료**

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- `useDebounce` 커스텀 훅을 구현해서 `util`에 넣어두었는데, **실제로 사용하려니 이벤트 객체 타입 문제 때문에 사용하지 못했습니다.**
  - 이 부분은 추후에 리팩토링하겠습니다.

## 🔎 PR포인트 및 궁금한 점
