### PR TITLE
Gmmq 351 style: 이력서 상세 페이지 레이아웃 구현

### DIFF
--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -1,0 +1,99 @@
+import { PhoneIcon } from '@chakra-ui/icons';
+import { Box, Flex, Heading, Tag, Text } from '@chakra-ui/react';
+import { BorderBox } from '../../atoms/BorderBox';
+
+/* NOTE
+  전체 콘텐츠의 가로 길이 960px
+  보더박스의 가로 길이 960px => 쉐도우 때문에 조금 줄여야 할 듯?
+  보더박스 내부 콘텐츠의 가로 길이 872 (mx=44px)
+ */
+
+/* TODO
+  1. 상단부
+  - 이름 텍스트
+  - 희망직무 태그
+  - 기술스택 레이블, 태그
+  - 전화번호?????
+  - 참고 링크 박스
+  - 자기소개
+
+  2. 업무경험
+  - 업무 경험 개별
+    - 주요 업무
+  3. 프로젝트
+  - 프로젝트 개별 반복
+  4. 교육
+  - 교육 개별 반복
+  5. 수상 및 경력
+  6. 외국어
+  7. 활동
+  8. 추가 커스텀 블록
+
+
+  추가 기능?
+  - 표시 순서를 바꿀 수 있게 할 수 있는가?
+    - 상태가 필요하고, 서버 데이터도 순서를 바꿔 보여줄 수 있는 플래그가 필요함
+*/
+
+const ResumeDetailTemplate = () => {
+  return (
+    <Flex
+      direction={'column'}
+      width={'960px'}
+      gap={6}
+    >
+      <Box mx={'1rem'}>
+        <Text>이력서 제목</Text>
+      </Box>
+      <BorderBox
+        hasShadow
+        border={'none'}
+        bg={'gray.100'}
+        height={'full'}
+        mx={'1rem'}
+      >
+        {/* 상단부 */}
+        <Flex justify={'space-between'}>
+          {/* 상단부 - 이름, 직무, 보유 기술스택 */}
+          <Flex
+            className="Head1"
+            direction={'column'}
+          >
+            <Text>이름</Text>
+            <Tag>프론트엔드</Tag>
+            <Flex direction={'column'}>
+              <Text>기술 스택</Text>
+              <Box>
+                <Tag>자바스크립트</Tag>
+                <Tag>자바스크립트</Tag>
+              </Box>
+            </Flex>
+          </Flex>
+          {/* 상단부 - 전화번호, 참고링크, 자기소개 */}
+          <Flex className="Head2">
+            <Flex>
+              <PhoneIcon />
+              <Text>010-0000-0000</Text>
+            </Flex>
+          </Flex>
+        </Flex>
+        <Flex direction={'column'}>
+          {/* 카테고리 블록 */}
+          <Box>
+            <Box>
+              <Text>업무경험</Text>
+            </Box>
+            <BorderBox p={10}>
+              <Flex>
+                <Box width={'25%'}>기간 및 날짜 데이터</Box>
+                <Box>데이터 내용 (세부 구조 구체화)</Box>
+              </Flex>
+            </BorderBox>
+          </Box>
+        </Flex>
+      </BorderBox>
+    </Flex>
+  );
+};
+
+export default ResumeDetailTemplate;

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -43,7 +43,13 @@ const ResumeDetailTemplate = () => {
       gap={6}
     >
       <Box mx={'1rem'}>
-        <Text>이력서 제목</Text>
+        <Text
+          fontSize={'2xl'}
+          fontWeight={'bold'}
+          color={'gray.800'}
+        >
+          이력서 제목
+        </Text>
       </Box>
       <BorderBox
         hasShadow

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -1,5 +1,5 @@
 import { PhoneIcon } from '@chakra-ui/icons';
-import { Box, Flex, Heading, Tag, Text } from '@chakra-ui/react';
+import { Box, Flex, Tag, Text } from '@chakra-ui/react';
 import { BorderBox } from '../../atoms/BorderBox';
 
 /* NOTE

--- a/src/components/templates/ResumeDetailTemplate/index.ts
+++ b/src/components/templates/ResumeDetailTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as ResumeDetailTemplate } from './ResumeDetailTemplate';

--- a/src/pages/ResumePages/ResumeDetailPage/ResumeDetailPage.tsx
+++ b/src/pages/ResumePages/ResumeDetailPage/ResumeDetailPage.tsx
@@ -1,5 +1,7 @@
+import { ResumeDetailTemplate } from '~/components/templates/ResumeDetailTemplate';
+
 const ResumeDetailPage = () => {
-  return <></>;
+  return <ResumeDetailTemplate />;
 };
 
 export default ResumeDetailPage;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/e867a251-ee85-40d9-b923-dc5cb9ace90c)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
이력서 상세 페이지의 레이아웃을 구현했습니다.
- `ResumeDetailTemplate.tsx` 컴포넌트입니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 저도 모르게 UI를 구현하다가 멈추고, 레이아웃 구현 부분만 커밋하여 PR합니다.
- Chakra UI의 `Flex`를 주로 활용했습니다.

## 🔎 PR포인트 및 궁금한 점
- 레이아웃만 들어있어서 그렇게 볼만한 코드는 없습니다.