### PR TITLE
Gmmq 310 fix: errors에서 error로 변경, 의미에 맞게 사용, 일관성 개선

### DIFF
--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -1,17 +1,15 @@
 import { Input, InputProps, FormErrorMessage, Flex } from '@chakra-ui/react';
 import { ReactNode } from 'react';
-import { FieldError, FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 type TitleInputProps = {
   id?: string;
   register?: UseFormRegisterReturn;
-  error?: FieldError | FieldErrors;
+  error?: FieldError;
   children?: ReactNode;
 } & Omit<InputProps, 'type'>;
 
 const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps) => {
-  const errorMessage = error && 'message' in error ? (error.message as string) : '';
-
   return (
     <Flex
       direction={'column'}
@@ -36,7 +34,7 @@ const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps
       >
         {children}
       </Input>
-      {error && <FormErrorMessage>{errorMessage}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -7,7 +7,7 @@ type TitleInputProps = {
   register?: UseFormRegisterReturn;
   error?: FieldError;
   children?: ReactNode;
-} & Omit<InputProps, 'type'>;
+} & InputProps;
 
 const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps) => {
   return (

--- a/src/components/molecules/FormDateInput/FormDateInput.tsx
+++ b/src/components/molecules/FormDateInput/FormDateInput.tsx
@@ -5,14 +5,14 @@ type FormDateInputProps = {
   type?: 'date' | 'datetime-local';
   register: UseFormRegisterReturn;
   isDisabled?: boolean;
-  errors?: FieldError;
+  error?: FieldError;
 } & Omit<InputProps, 'type'>;
 
 const FormDateInput = ({
   type = 'date',
   isDisabled = false,
   register,
-  errors,
+  error,
   ...props
 }: FormDateInputProps) => {
   return (
@@ -26,7 +26,7 @@ const FormDateInput = ({
         {...register}
         {...props}
       />
-      {errors && <FormErrorMessage>{errors && (errors.message as string)}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextarea/FormTextarea.tsx
+++ b/src/components/molecules/FormTextarea/FormTextarea.tsx
@@ -1,13 +1,13 @@
 import { FormErrorMessage, Flex, Textarea, TextareaProps } from '@chakra-ui/react';
-import { FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 type FormTextInputProps = {
   id: string;
   register: UseFormRegisterReturn;
-  errors: FieldErrors;
+  error?: FieldError;
 } & TextareaProps;
 
-const FormTextarea = ({ h = '26.75rem', id, register, errors, ...props }: FormTextInputProps) => {
+const FormTextarea = ({ h = '26.75rem', id, register, error, ...props }: FormTextInputProps) => {
   return (
     <Flex
       direction={'column'}
@@ -19,7 +19,7 @@ const FormTextarea = ({ h = '26.75rem', id, register, errors, ...props }: FormTe
         {...register}
         {...props}
       />
-      {errors[id]?.message && <FormErrorMessage>{errors[id]?.message as string}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextarea/index.stories.tsx
+++ b/src/components/molecules/FormTextarea/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import { useForm } from 'react-hook-form';
+import { FieldError, useForm } from 'react-hook-form';
 import FormTextarea from './FormTextarea';
 import FormControl from '../FormControl/FormControl';
 import { BorderBox } from '~/components/atoms/BorderBox';
@@ -43,7 +43,7 @@ export const DefaultFormTextarea = () => {
             내용
           </FormLabel>
           <FormTextarea
-            errors={errors}
+            error={errors['content'] as FieldError}
             id="content"
             register={{ ...register('content', { required: true }) }}
             placeholder="이벤트에 대한 상세 내용을 입력해주세요."

--- a/src/components/molecules/TermInput/TermInput.tsx
+++ b/src/components/molecules/TermInput/TermInput.tsx
@@ -58,7 +58,7 @@ const TermInput = <T extends FieldValues>({
               },
             }),
           }}
-          errors={getNestedError(errors, startDateName)}
+          error={getNestedError(errors, startDateName)}
         />
       </FormControl>
       <Divider
@@ -76,7 +76,7 @@ const TermInput = <T extends FieldValues>({
               min: { value: startDate, message: '시작일 이후의 날짜를 입력해주세요.' },
             }),
           }}
-          errors={getNestedError(errors, endDateName)}
+          error={getNestedError(errors, endDateName)}
         />
       </FormControl>
     </HStack>

--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -122,7 +122,7 @@ const BasicInfoForm = () => {
                   },
                 }),
               }}
-              errors={errors}
+              error={errors.introduce}
               height="100px"
               width="full"
               placeholder="간략한 자기소개 (100자 이내)"

--- a/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
+++ b/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
@@ -122,7 +122,7 @@ const ActivityForm = () => {
             placeholder="내용을 입력해주세요."
             id="description"
             register={{ ...register('description') }}
-            errors={errors}
+            error={errors.description}
           />
         </FormControl>
         <HStack>

--- a/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
+++ b/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
@@ -112,7 +112,7 @@ const AwardForm = () => {
             placeholder="내용을 입력해주세요."
             id="description"
             register={{ ...register('description') }}
-            errors={errors}
+            error={errors.description}
             autoComplete="off"
             spellCheck="false"
             resize="none"

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -158,7 +158,7 @@ const ProjectForm = () => {
             placeholder="프로젝트에 대한 내용을 입력해주세요."
             id="projectContent"
             register={{ ...register('projectContent') }}
-            errors={errors}
+            error={errors.projectContent}
           />
         </FormControl>
         <FormControl isInvalid={Boolean(errors.projectUrl)}>

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -125,7 +125,7 @@ const TrainingForm = () => {
                   },
                 }),
               }}
-              errors={errors.admissionDate}
+              error={errors.admissionDate}
             />
           </FormControl>
           <FormControl isInvalid={Boolean(errors.graduationDate)}>
@@ -137,7 +137,7 @@ const TrainingForm = () => {
                   min: { value: watch('admissionDate'), message: '유효한 날짜를 입력해 주세요.' },
                 }),
               }}
-              errors={errors.graduationDate}
+              error={errors.graduationDate}
             />
           </FormControl>
         </Flex>
@@ -192,7 +192,7 @@ const TrainingForm = () => {
             placeholder="내용을 입력해주세요."
             id="projectContent"
             register={{ ...register('explanation') }}
-            errors={errors}
+            error={errors.explanation}
           />
         </FormControl>
         <HStack

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -114,7 +114,7 @@ const CreateEventTemplate = () => {
             <FormControl isInvalid={!!errors.time?.endDate}>
               <FormLabel isRequired={true}>첨삭 종료일</FormLabel>
               <FormDateInput
-                errors={errors.time?.endDate}
+                error={errors.time?.endDate}
                 w={'47.6%'}
                 register={{
                   ...register('time.endDate', {
@@ -138,7 +138,7 @@ const CreateEventTemplate = () => {
                 내용
               </FormLabel>
               <FormTextarea
-                errors={errors}
+                error={errors.info?.content}
                 id="info.content"
                 register={{ ...register('info.content', { required: true }) }}
                 placeholder="이벤트에 대한 상세 내용을 입력해주세요."


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
FormTextInput과 같은 곳에서 props의 이름이 일정하지 않았던 점을 수정했습니다.
ex) FormTextarea => error 프롭, FormTextInput => errors 프롭
사용하는 곳에서도 error에 errors전체를 넣는 것이 아니라 해당 FormContorl에서 관리하는 값을 넣도록 코드를 개선했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점

