### PR TITLE
Gmmq 326 feat: 가입 페이지 스텝별로 템플릿 컴포넌트 분리, 스텝 및 데이터 상태관리

### DIFF
--- a/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
+++ b/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
@@ -9,18 +9,22 @@ import { RadioCardGroup } from '~/components/organisms/RadioCardGroup';
 import { RadioOption } from '~/components/organisms/RadioCardGroup/RadioCardGroup';
 import { assets } from '~/config/assets';
 import CONSTANTS from '~/constants';
-import { Role, SignUpCommon } from '~/types/signUp';
+import { SignUpRole, SignUpCommon } from '~/types/signUp';
 
-const SignUpCommonTemplate = () => {
+type SignUpCommonTemplateProps = {
+  onNext: (values: SignUpCommon<SignUpRole>) => void;
+};
+
+const SignUpCommonTemplate = ({ onNext }: SignUpCommonTemplateProps) => {
   const {
     register,
     handleSubmit,
     formState: { errors, isSubmitting },
-  } = useForm<SignUpCommon<Role>>();
+  } = useForm<SignUpCommon<SignUpRole>>();
 
-  const onSubmit = (values: SignUpCommon<Role>) => {
+  const onSubmit = (values: SignUpCommon<SignUpRole>) => {
     /**TODO - cacheKey zustand 스토어에서 받아와서 가입 요청 시 api에 함께 전송하기 */
-    console.log(values);
+    onNext(values);
   };
 
   const ROLE_ASSETS = {
@@ -38,7 +42,7 @@ const SignUpCommonTemplate = () => {
     },
   } as const;
 
-  const ROLE_OPTIONS: RadioOption<Role>[] = [
+  const ROLE_OPTIONS: RadioOption<SignUpRole>[] = [
     {
       value: ROLE_ASSETS.mentee.value,
       children: <RoleButton {...ROLE_ASSETS.mentee} />,

--- a/src/components/templates/SignUpCommonTemplate/index.ts
+++ b/src/components/templates/SignUpCommonTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpCommonTemplate } from './SignUpCommonTemplate';

--- a/src/components/templates/SignUpCompleteTemplate/SignUpCompleteTemplate.tsx
+++ b/src/components/templates/SignUpCompleteTemplate/SignUpCompleteTemplate.tsx
@@ -1,0 +1,5 @@
+const SignUpCompleteTemplate = () => {
+  return <></>;
+};
+
+export default SignUpCompleteTemplate;

--- a/src/components/templates/SignUpCompleteTemplate/index.ts
+++ b/src/components/templates/SignUpCompleteTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpCompleteTemplate } from './SignUpCompleteTemplate';

--- a/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
+++ b/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
@@ -1,0 +1,5 @@
+const SignUpMenteeTemplate = () => {
+  return <></>;
+};
+
+export default SignUpMenteeTemplate;

--- a/src/components/templates/SignUpMenteeTemplate/index.ts
+++ b/src/components/templates/SignUpMenteeTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpMenteeTemplate } from './SignUpMenteeTemplate';

--- a/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
+++ b/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
@@ -1,0 +1,5 @@
+const SignUpMentorTemplate = () => {
+  return <></>;
+};
+
+export default SignUpMentorTemplate;

--- a/src/components/templates/SignUpMentorTemplate/index.ts
+++ b/src/components/templates/SignUpMentorTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as SignUpMentorTemplate } from './SignUpMentorTemplate';

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,7 +1,33 @@
-import SignUpCommonTemplate from '~/components/templates/SignUpCommonTemplate/SignUpCommonTemplate';
+import { useState } from 'react';
+import { SignUpCommonTemplate } from '~/components/templates/SignUpCommonTemplate';
+import { SignUpMenteeTemplate } from '~/components/templates/SignUpMenteeTemplate';
+import { SignUpMentorTemplate } from '~/components/templates/SignUpMentorTemplate';
+import { SignUpRole, SignUpMentee, SignUpMentor, SignUpCommon } from '~/types/signUp';
+
+export type Step = 'COMMON' | SignUpRole | 'COMPLETE';
 
 const SignUpPage = () => {
-  return <SignUpCommonTemplate />;
+  const [step, setStep] = useState<Step>('COMMON');
+  const [commonData, setCommonData] = useState<SignUpCommon<SignUpRole>>();
+  const [menteeData, setMenteeData] = useState<SignUpMentee>();
+  const [mentorData, setMentorData] = useState<SignUpMentor>();
+  /*FIXME - 사용하지 않는 변수 lint에러 방지용 로그 .. 삭제 필요! */
+  console.log(commonData, menteeData, setMenteeData, mentorData, setMentorData);
+  return (
+    <>
+      {step === 'COMMON' && (
+        <SignUpCommonTemplate
+          onNext={(data) => {
+            setStep(data.role);
+            setCommonData(data);
+          }}
+        />
+      )}
+      {/**TODO - onNext에 각각 menteeData, mentorData를 바디로 api 호출 (commonData 삽입해서) */}
+      {step === 'ROLE_PENDING' && <SignUpMentorTemplate />}
+      {step === 'ROLE_MENTEE' && <SignUpMenteeTemplate />}
+    </>
+  );
 };
 
 export default SignUpPage;

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { SignUpCommonTemplate } from '~/components/templates/SignUpCommonTemplate';
+import { SignUpCompleteTemplate } from '~/components/templates/SignUpCompleteTemplate';
 import { SignUpMenteeTemplate } from '~/components/templates/SignUpMenteeTemplate';
 import { SignUpMentorTemplate } from '~/components/templates/SignUpMentorTemplate';
 import { SignUpRole, SignUpMentee, SignUpMentor, SignUpCommon } from '~/types/signUp';
@@ -26,6 +27,7 @@ const SignUpPage = () => {
       {/**TODO - onNext에 각각 menteeData, mentorData를 바디로 api 호출 (commonData 삽입해서) */}
       {step === 'ROLE_PENDING' && <SignUpMentorTemplate />}
       {step === 'ROLE_MENTEE' && <SignUpMenteeTemplate />}
+      {step === 'COMPLETE' && <SignUpCompleteTemplate />}
     </>
   );
 };

--- a/src/types/signUp.ts
+++ b/src/types/signUp.ts
@@ -7,22 +7,28 @@ export type SignUpMentor = {
   experiencedPositions: Position[];
   careerContent: string;
   careerYear: number;
-  introduce: string;
+  introduce?: string;
 };
 
 export type SignUpMentee = {
-  cacheKey: 'cacheKey';
+  cacheKey: string;
   requiredInfo: SignUpCommon<'ROLE_MENTEE'>;
-  interestedPositions: Position[];
-  interestedFields: Fields[];
-  introduce: string;
+  interestedPositions?: Position[];
+  interestedFields?: Fields[];
+  introduce?: string;
 };
 
-export type SignUpCommon<T extends Role> = {
+export type SignUpCommon<T extends Exclude<Role, 'ROLE_MENTOR'>> = {
   nickname: string;
   realName: string;
   phoneNumber: string;
   role: T;
 };
 
+/**
+ * ROLE_PENDING: 멘토로 가입했지만 어드민의 승인이 아직 없는 상태
+ * ROLE_MENTOR: 멘토로 가입해서 어드민의 승인까지 받은 상태
+ */
 export type Role = 'ROLE_PENDING' | 'ROLE_MENTOR' | 'ROLE_MENTEE';
+
+export type SignUpRole = Exclude<Role, 'ROLE_MENTOR'>;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 페이지 이동 없이 컴포넌트만 바뀌며 가입 완료까지 가는 형식입니다.
- 어떤 단계의 컴포넌트를 렌더링해야 하는지 파악하기 위해 step 상태를 사용합니다.
- 유지보수의 용이성을 위해 코드의 응집도를 높이려면 각각의 컴포넌트 내에서 데이터를 처리하는 것이 아니라 페이지 컴포넌트 한 곳에서 모두 처리하는 게 좋다고 하더라구요. 
그래서 폼에서는 데이터를 페이지(부모 컴포넌트)로 올려주기만 하고, `데이터 상태 관리 + step넘기는 작업`은 페이지에서 처리하도록 했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- [참고 영상](https://www.youtube.com/watch?v=NwLWX2RNVcw)
- 페이지를 이탈하면 처음부터 다시 해야 하니, 사용자가 현재 페이지를 이탈하려 하면 alert를 띄워주는 훅을 만들어야 할 것 같습니다. (react router에서 제공하는 `useBeforeUnload` 훅이 있는데, 이건 새로고침할 때만 작동하고, SPA 구조에서 뒤로 가기 등 페이지를 이동하려 할 때는 작동을 안합니다.) ([참고](https://1ilsang.dev/posts/js/use-prevet-leave))
## 🔎 PR포인트 및 궁금한 점
얽혀있는 작업들을 한 번에 하다보니.. 커밋 단위가 크네요 😅