### PR TITLE
Gmmq 344 style: 이력서 상세 페이지 - 업무경험 UI 구현

### DIFF
--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,6 +1,6 @@
-import { Divider } from '@chakra-ui/react';
+import { Box, Text, Flex, Divider, Heading } from '@chakra-ui/react';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import Career from '~/types/career';
 
 const CareerDetails = ({ data }: { data: Career[] }) => {
@@ -10,38 +10,138 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
   return (
     <>
       {data?.map(
-        ({
-          companyName,
-          position,
-          skills,
-          duties,
-          careerStartDate,
-          isCurrentlyEmployed,
-          endDate,
-          careerContent,
-        }: Career) => {
+        (
+          {
+            companyName,
+            position,
+            skills,
+            duties,
+            careerStartDate,
+            isCurrentlyEmployed,
+            endDate,
+            careerContent,
+          }: Career,
+          i,
+        ) => {
           return (
-            <BorderBox
-              key={uuidv4()}
-              w={'100%'}
-            >
-              <div>{companyName}</div>
-              <div>{position}</div>
-              <div>{skills}</div>
-              <Divider />
-              {duties?.map((duty) => (
-                <div key={uuidv4()}>
-                  <span>{duty.title}</span>
-                  <span>{duty.startDate}</span>
-                  <span>{duty.endDate}</span>
-                  <span>{duty.description}</span>
-                </div>
-              ))}
+            <>
+              {i > 0 && (
+                <Divider
+                  key={i}
+                  my={'3rem'}
+                  borderColor={'gray.300'}
+                />
+              )}
+              <Flex key={uuidv4()}>
+                <Flex flex={1}>
+                  {/* NOTE 기간 및 날짜 데이터 */}
+                  <Flex direction={'column'}>
+                    <Flex
+                      justify={'start'}
+                      align={'center'}
+                      gap={2}
+                    >
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        h={'fit-content'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {careerStartDate}
+                      </Label>
+                      <Text display={'inline-block'}>-</Text>
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {isCurrentlyEmployed ? '재직중' : endDate}
+                      </Label>
+                    </Flex>
+                  </Flex>
+                </Flex>
 
-              <div>{careerStartDate}</div>
-              {isCurrentlyEmployed && <div>{endDate}</div>}
-              <div>{careerContent}</div>
-            </BorderBox>
+                {/* NOTE 데이터 내용 */}
+                <Flex
+                  mt={'1%'}
+                  flex={2}
+                  direction={'column'}
+                >
+                  <Flex
+                    direction={'column'}
+                    width={'full'}
+                    gap={2}
+                  >
+                    <Heading
+                      fontSize={'xl'}
+                      fontWeight={'bold'}
+                      color={'gray.800'}
+                    >
+                      {companyName}
+                    </Heading>
+                    <Text
+                      fontWeight={'semibold'}
+                      color={'gray.800'}
+                    >
+                      {position}
+                    </Text>
+                    <Flex
+                      direction={'column'}
+                      pl={1}
+                      gap={2}
+                    >
+                      <Flex
+                        pt={2}
+                        gap={2}
+                        flexWrap={'wrap'}
+                      >
+                        {skills?.map((skill, i) => (
+                          <Label
+                            key={i}
+                            width={'fit-content'}
+                            bg={'gray.500'}
+                            fontSize={'xs'}
+                            py={0}
+                            color={'gray.100'}
+                            fontWeight={'medium'}
+                          >
+                            {skill}
+                          </Label>
+                        ))}
+                      </Flex>
+                      <Text mt={5}>{careerContent}</Text>
+                    </Flex>
+                  </Flex>
+                  {duties?.map((duty) => (
+                    <Box key={uuidv4()}>
+                      <Flex
+                        direction={'column'}
+                        mt={10}
+                      >
+                        <Text fontWeight={'bold'}>{duty.title}</Text>
+                      </Flex>
+                      <Flex>
+                        <Flex
+                          direction={'column'}
+                          gap={3}
+                        >
+                          <Text
+                            fontSize={'xs'}
+                            fontWeight={'regular'}
+                            color={'gray.500'}
+                          >
+                            {duty.startDate} - {duty.endDate}
+                          </Text>
+                          <Text>{duty.description}</Text>
+                        </Flex>
+                      </Flex>
+                    </Box>
+                  ))}
+                </Flex>
+              </Flex>
+            </>
           );
         },
       )}

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, Flex, Divider, Heading } from '@chakra-ui/react';
+import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { Label } from '~/components/atoms/Label';
 import Career from '~/types/career';
@@ -24,7 +25,7 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
           i,
         ) => {
           return (
-            <>
+            <React.Fragment key={uuidv4()}>
               {i > 0 && (
                 <Divider
                   key={i}
@@ -141,7 +142,7 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
                   ))}
                 </Flex>
               </Flex>
-            </>
+            </React.Fragment>
           );
         },
       )}

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -3,39 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
-
-/* NOTE
-  전체 콘텐츠의 가로 길이 960px
-  보더박스의 가로 길이 960px => 쉐도우 때문에 조금 줄여야 할 듯?
-  보더박스 내부 콘텐츠의 가로 길이 872 (mx=44px)
- */
-
-/* TODO
-  1. 상단부
-  - 이름 텍스트
-  - 희망직무 태그
-  - 기술스택 레이블, 태그
-  - 전화번호?????
-  - 참고 링크 박스
-  - 자기소개
-
-  2. 업무경험
-  - 업무 경험 개별
-    - 주요 업무
-  3. 프로젝트
-  - 프로젝트 개별 반복
-  4. 교육
-  - 교육 개별 반복
-  5. 수상 및 경력
-  6. 외국어
-  7. 활동
-  8. 추가 커스텀 블록
-
-
-  추가 기능?
-  - 표시 순서를 바꿀 수 있게 할 수 있는가?
-    - 상태가 필요하고, 서버 데이터도 순서를 바꿔 보여줄 수 있는 플래그가 필요함
-*/
+import { CareerDetails } from '~/components/organisms/ResumeDetails';
 
 const DUMMY_DATA = {
   userInfo: {
@@ -63,6 +31,68 @@ const DUMMY_DATA = {
     },
   ],
 };
+
+const CAREER_DUMMY_DATA = [
+  {
+    companyName: '아몬드빼빼로',
+    position: '주니어 프론트엔드 개발자',
+    isCurrentlyEmployed: true,
+    skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
+    duties: [
+      {
+        title: '중요한 업무업무',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+      {
+        title:
+          '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 해야데이엄? 더 길게 한다 더 길게',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+      {
+        title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+    ],
+    careerStartDate: '2000-00-00',
+    endDate: '2000-00-01',
+    careerContent: '어쩌구 저쩌구',
+  },
+  {
+    companyName: '아몬드빼빼로',
+    position: '주니어 프론트엔드 개발자',
+    isCurrentlyEmployed: true,
+    skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
+    duties: [
+      {
+        title: '중요한 업무업무',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+      {
+        title: '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 할려궁?',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+      {
+        title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
+        description: '중요한 업무를 했다 와 힘들었따',
+        startDate: '2000-00-00',
+        endDate: '2000-00-01',
+      },
+    ],
+    careerStartDate: '2000-00-00',
+    endDate: '2000-00-01',
+    careerContent: '어쩌구 저쩌구',
+  },
+];
 
 const ResumeDetailTemplate = () => {
   return (
@@ -202,26 +232,34 @@ const ResumeDetailTemplate = () => {
               <Text>{DUMMY_DATA.basicInfo.introduce}</Text>
             </BorderBox>
           </Flex>
-          <Box
-            width={'100%'}
-            m={'auto'}
-            borderBottom={'1px'}
-            borderBottomColor={'gray.300'}
-          />
           {/* NOTE LowerPart - 하단부 UI */}
-          <Flex direction={'column'}>
+          <Flex
+            direction={'column'}
+            gap={10}
+          >
             {/* NOTE LowerPart - 하단부 - 업무경험 UI */}
-            <Box>
+            <Flex
+              direction={'column'}
+              gap={1}
+            >
               <Box>
-                <Text>업무경험</Text>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  업무경험
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  p={7}
+                  gap={10}
+                >
+                  <CareerDetails data={CAREER_DUMMY_DATA} />
+                </BorderBox>
               </Box>
-              <BorderBox p={10}>
-                <Flex>
-                  <Box width={'25%'}>기간 및 날짜 데이터</Box>
-                  <Box>데이터 내용 (세부 구조 구체화)</Box>
-                </Flex>
-              </BorderBox>
-            </Box>
+            </Flex>
           </Flex>
         </Flex>
       </BorderBox>


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/622c213c-ad07-4943-ad87-0131b5c7fce7)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 상세 페이지의 업무경험 블록 UI를 구현했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
### 아직 컴포넌트를 완전히 분할하지 않았습니다.
- 업무경험 블록 UI만 `CareerDetails` 코드에 적용한 상태입니다.
- 상단부는 아직 분할되지 않아 ResumeDetialTemplate 코드가 지저분한 상태에요. 감안해주세요.

### CareerDetails 컴포넌트 관련 문제
- `CareerDetails` 컴포넌트를 이력서 작성/수정 페이지에서도 렌더링하고 있는데, 이 때 BorderBox가 없어서 이력서 작성/수정 페이지의 UI가 깨집니다.
- 구조적인 문제입니다.
  - 디자인 시안에서 이력서 상세 페이지의 업무경험 블록은 하나의 BorderBox로 되어 있습니다.
  - 그런데 이력서 작성/수정 페이지의 **업무경험 및 다른 카테고리 블록들은 데이터가 있을때만 BorderBox가 생겨야 합니다.**

### 현재는 더미 데이터가 들어가 있어요.
- 이력서 상세 전체 조회 api가 생기면 수정할 예정입니다.
## 🔎 PR포인트 및 궁금한 점
