### PR TITLE
Gmmq 328 feat: 멘토 가입 페이지 작성

### DIFF
--- a/src/api/event/details/getEventDetail.ts
+++ b/src/api/event/details/getEventDetail.ts
@@ -4,10 +4,10 @@ import { ReadEvent } from '~/types/event';
 export type GetEventDetail = { eventId?: string };
 
 export const getEventDetail = async ({ eventId }: GetEventDetail): Promise<ReadEvent> => {
-  const { data } = await resumeMeAxios.get(`/v1/Events/${eventId}`, {
+  const { data } = await resumeMeAxios.get(`/v1/events/${eventId}`, {
     headers: {
       /**FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-      Authorization: import.meta.env.VITE_TEMP_MENTEE_TOKEN,
+      Authorization: import.meta.env.VITE_TEMP_MENTOR_TOKEN,
     },
   });
   return data;

--- a/src/components/atoms/FormLabel/FormLabel.tsx
+++ b/src/components/atoms/FormLabel/FormLabel.tsx
@@ -2,13 +2,24 @@ import {
   Box,
   FormLabel as ChakraFormLabel,
   FormLabelProps as ChakraFormLabelProps,
+  Flex,
+  Text,
 } from '@chakra-ui/react';
 
 export type FormLabelProps = {
   isRequired?: boolean;
+  subText?: string;
+  subTextDirection?: 'row' | 'column';
 } & ChakraFormLabelProps;
 
-const FormLabel = ({ w = '6.9375rem', children, isRequired = false, ...props }: FormLabelProps) => {
+const FormLabel = ({
+  w = '6.9375rem',
+  children,
+  isRequired = false,
+  subText,
+  subTextDirection = 'row',
+  ...props
+}: FormLabelProps) => {
   return (
     <ChakraFormLabel
       flexShrink={0}
@@ -20,17 +31,29 @@ const FormLabel = ({ w = '6.9375rem', children, isRequired = false, ...props }: 
       mt={'0.87rem'}
       color={'gray.700'}
       p={0}
+      display={subText ? 'flex' : 'block'}
+      flexDirection={subTextDirection}
       {...props}
     >
-      {children}
-      {isRequired && (
-        <Box
-          as="span"
-          color="primary.900"
+      <Flex gap={'2px'}>
+        {children}
+        {isRequired && (
+          <Box
+            as="span"
+            color="primary.900"
+            flexDirection={'row'}
+          >
+            *
+          </Box>
+        )}
+      </Flex>
+      {subText && (
+        <Text
+          color={'gray.500'}
+          fontWeight={'light'}
         >
-          {' '}
-          *
-        </Box>
+          {subText}
+        </Text>
       )}
     </ChakraFormLabel>
   );

--- a/src/components/atoms/TitleInput/TitleInput.tsx
+++ b/src/components/atoms/TitleInput/TitleInput.tsx
@@ -1,17 +1,15 @@
 import { Input, InputProps, FormErrorMessage, Flex } from '@chakra-ui/react';
 import { ReactNode } from 'react';
-import { FieldError, FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 type TitleInputProps = {
   id?: string;
   register?: UseFormRegisterReturn;
-  error?: FieldError | FieldErrors;
+  error?: FieldError;
   children?: ReactNode;
-} & Omit<InputProps, 'type'>;
+} & InputProps;
 
 const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps) => {
-  const errorMessage = error && 'message' in error ? (error.message as string) : '';
-
   return (
     <Flex
       direction={'column'}
@@ -36,7 +34,7 @@ const TitleInput = ({ id, register, error, children, ...props }: TitleInputProps
       >
         {children}
       </Input>
-      {error && <FormErrorMessage>{errorMessage}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormDateInput/FormDateInput.tsx
+++ b/src/components/molecules/FormDateInput/FormDateInput.tsx
@@ -5,14 +5,14 @@ type FormDateInputProps = {
   type?: 'date' | 'datetime-local';
   register: UseFormRegisterReturn;
   isDisabled?: boolean;
-  errors?: FieldError;
+  error?: FieldError;
 } & Omit<InputProps, 'type'>;
 
 const FormDateInput = ({
   type = 'date',
   isDisabled = false,
   register,
-  errors,
+  error,
   ...props
 }: FormDateInputProps) => {
   return (
@@ -26,7 +26,7 @@ const FormDateInput = ({
         {...register}
         {...props}
       />
-      {errors && <FormErrorMessage>{errors && (errors.message as string)}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextarea/FormTextarea.tsx
+++ b/src/components/molecules/FormTextarea/FormTextarea.tsx
@@ -1,13 +1,13 @@
 import { FormErrorMessage, Flex, Textarea, TextareaProps } from '@chakra-ui/react';
-import { FieldErrors, UseFormRegisterReturn } from 'react-hook-form';
+import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 
 type FormTextInputProps = {
   id: string;
   register: UseFormRegisterReturn;
-  errors: FieldErrors;
+  error?: FieldError;
 } & TextareaProps;
 
-const FormTextarea = ({ h = '26.75rem', id, register, errors, ...props }: FormTextInputProps) => {
+const FormTextarea = ({ h = '26.75rem', id, register, error, ...props }: FormTextInputProps) => {
   return (
     <Flex
       direction={'column'}
@@ -19,7 +19,7 @@ const FormTextarea = ({ h = '26.75rem', id, register, errors, ...props }: FormTe
         {...register}
         {...props}
       />
-      {errors[id]?.message && <FormErrorMessage>{errors[id]?.message as string}</FormErrorMessage>}
+      {error && <FormErrorMessage>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/FormTextarea/index.stories.tsx
+++ b/src/components/molecules/FormTextarea/index.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta } from '@storybook/react';
-import { useForm } from 'react-hook-form';
+import { FieldError, useForm } from 'react-hook-form';
 import FormTextarea from './FormTextarea';
 import FormControl from '../FormControl/FormControl';
 import { BorderBox } from '~/components/atoms/BorderBox';
@@ -43,7 +43,7 @@ export const DefaultFormTextarea = () => {
             내용
           </FormLabel>
           <FormTextarea
-            errors={errors}
+            error={errors['content'] as FieldError}
             id="content"
             register={{ ...register('content', { required: true }) }}
             placeholder="이벤트에 대한 상세 내용을 입력해주세요."

--- a/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
+++ b/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
@@ -1,5 +1,5 @@
-import { CheckboxGroup, CheckboxGroupProps, Stack } from '@chakra-ui/react';
-import { Controller, Control, FieldValues, Path } from 'react-hook-form';
+import { CheckboxGroup, CheckboxGroupProps, Flex, FormErrorMessage, Stack } from '@chakra-ui/react';
+import { Controller, Control, FieldValues, Path, FieldError } from 'react-hook-form';
 import CheckboxStyled from './CheckboxStyled';
 
 export type LabelCheckboxGroupProps<T extends FieldValues> = CheckboxGroupProps & {
@@ -9,6 +9,8 @@ export type LabelCheckboxGroupProps<T extends FieldValues> = CheckboxGroupProps 
   name: Path<T>;
   required?: boolean;
   control: Control<T>;
+  error?: Partial<FieldError>;
+  errorMessage?: string;
 };
 
 const role = [
@@ -34,7 +36,9 @@ const LabelCheckboxGroup = <T extends FieldValues>({
   spacing = '12px',
   name,
   control,
+  error,
   required = true,
+  errorMessage = '선택해주세요.',
   ...props
 }: LabelCheckboxGroupProps<T>) => {
   let selectedOptions = options;
@@ -44,7 +48,7 @@ const LabelCheckboxGroup = <T extends FieldValues>({
   }
 
   return (
-    <>
+    <Flex direction={'column'}>
       <Controller
         name={name}
         control={control}
@@ -71,9 +75,10 @@ const LabelCheckboxGroup = <T extends FieldValues>({
             </Stack>
           </CheckboxGroup>
         )}
-        rules={{ required }}
+        rules={{ required: required ? errorMessage : false }}
       />
-    </>
+      {error && <FormErrorMessage alignSelf={'start'}>{error.message as string}</FormErrorMessage>}
+    </Flex>
   );
 };
 

--- a/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
+++ b/src/components/molecules/LabelCheckboxGroup/LabelCheckboxGroup.tsx
@@ -77,7 +77,7 @@ const LabelCheckboxGroup = <T extends FieldValues>({
         )}
         rules={{ required: required ? errorMessage : false }}
       />
-      {error && <FormErrorMessage alignSelf={'start'}>{error.message as string}</FormErrorMessage>}
+      {error && <FormErrorMessage alignSelf={'start'}>{error.message}</FormErrorMessage>}
     </Flex>
   );
 };

--- a/src/components/molecules/MentorProfile/MentorProfile.tsx
+++ b/src/components/molecules/MentorProfile/MentorProfile.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Heading, Text, VStack } from '@chakra-ui/react';
+import { Flex, Heading, Text, VStack } from '@chakra-ui/react';
 import { Avatar } from '~/components/atoms/Avatar';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
@@ -14,60 +14,62 @@ const MentorProfile = ({ mentor, event }: MentorProfileProps) => {
   const { nickname, introduce, imageUrl } = mentor;
 
   return (
-    <Box maxW="14.25rem">
-      <VStack gap={'1.56rem'}>
-        <Avatar
-          size="lg"
-          name={nickname}
-          src={imageUrl}
-        />
+    <VStack
+      w={'full'}
+      maxW="14.25rem"
+      gap={'1.56rem'}
+    >
+      <Avatar
+        size="lg"
+        name={nickname}
+        src={imageUrl}
+      />
+      <Flex
+        w={'100%'}
+        justifyContent={'space-between'}
+      >
+        <Heading
+          fontSize={'20px'}
+          color={'gray.800'}
+        >
+          {nickname}
+        </Heading>
+      </Flex>
+      <Flex
+        minH={'12.44rem'}
+        direction={'column'}
+        justifyContent={'space-between'}
+      >
+        <BorderBox>
+          <Text
+            noOfLines={6}
+            overflow={'hidden'}
+            color={'gray.700'}
+          >
+            {introduce}
+          </Text>
+        </BorderBox>
         <Flex
           w={'100%'}
           justifyContent={'space-between'}
+          mt={'1.56rem'}
         >
-          <Heading
-            fontSize={'20px'}
+          <Text
+            as={'span'}
             color={'gray.800'}
           >
-            {nickname}
-          </Heading>
-        </Flex>
-        <Flex
-          minH={'12.44rem'}
-          direction={'column'}
-          justifyContent={'space-between'}
-        >
-          <BorderBox>
-            <Text
-              noOfLines={6}
-              overflow={'hidden'}
-              color={'gray.700'}
-            >
-              {introduce}
-            </Text>
-          </BorderBox>
-          <Flex
-            w={'100%'}
-            justifyContent={'space-between'}
-            mt={'1.56rem'}
+            인원
+          </Text>
+          <Text
+            as={'span'}
+            color={'gray.800'}
           >
-            <Text
-              as={'span'}
-              color={'gray.800'}
-            >
-              인원
-            </Text>
-            <Text
-              as={'span'}
-              color={'gray.800'}
-            >
-              {event.info.currentApplicantCount}/{event.info.maximumCount}
-            </Text>
-          </Flex>
+            {event.info.currentApplicantCount}/{event.info.maximumCount}
+          </Text>
         </Flex>
-        <Button size={'full'}>신청하기</Button>
-      </VStack>
-    </Box>
+      </Flex>
+      <Button size={'full'}>신청하기</Button>
+    </VStack>
   );
 };
 

--- a/src/components/molecules/TermInput/TermInput.tsx
+++ b/src/components/molecules/TermInput/TermInput.tsx
@@ -58,7 +58,7 @@ const TermInput = <T extends FieldValues>({
               },
             }),
           }}
-          errors={getNestedError(errors, startDateName)}
+          error={getNestedError(errors, startDateName)}
         />
       </FormControl>
       <Divider
@@ -76,7 +76,7 @@ const TermInput = <T extends FieldValues>({
               min: { value: startDate, message: '시작일 이후의 날짜를 입력해주세요.' },
             }),
           }}
-          errors={getNestedError(errors, endDateName)}
+          error={getNestedError(errors, endDateName)}
         />
       </FormControl>
     </HStack>

--- a/src/components/organisms/EventDetail/EventDetail.tsx
+++ b/src/components/organisms/EventDetail/EventDetail.tsx
@@ -14,8 +14,8 @@ type EventDetailProps = {
 
 const EventDetail = ({ mentor, event }: EventDetailProps) => {
   const eventStatus =
-    event.info.maximumCount === event.info.currentApplicantCount ||
-    new Date().toISOString() > event.info.timeInfo.closeDateTime;
+    event.info.maximumCount > event.info.currentApplicantCount ||
+    new Date().toISOString() < event.info.timeInfo.closeDateTime;
 
   return (
     <Box w={'full'}>

--- a/src/components/organisms/EventDetail/EventTitle.tsx
+++ b/src/components/organisms/EventDetail/EventTitle.tsx
@@ -14,15 +14,13 @@ const EventTitle = ({ title, eventStatus }: EventTitle) => {
       justifyContent={'space-between'}
     >
       <Heading fontSize={'1.5rem'}>{title}</Heading>
-      {eventStatus && (
-        <Label
-          fontSize={'0.875rem'}
-          bg={'primary.900'}
-          textAlign={'center'}
-        >
-          모집 중
-        </Label>
-      )}
+      <Label
+        fontSize={'0.875rem'}
+        bg={eventStatus ? 'primary.900' : 'gray.500'}
+        textAlign={'center'}
+      >
+        {eventStatus ? '모집 중' : '모집 마감'}
+      </Label>
     </Flex>
   );
 };

--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -122,7 +122,7 @@ const BasicInfoForm = () => {
                   },
                 }),
               }}
-              errors={errors}
+              error={errors.introduce}
               height="100px"
               width="full"
               placeholder="간략한 자기소개 (100자 이내)"

--- a/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
+++ b/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
@@ -122,7 +122,7 @@ const ActivityForm = () => {
             placeholder="내용을 입력해주세요."
             id="description"
             register={{ ...register('description') }}
-            errors={errors}
+            error={errors.description}
           />
         </FormControl>
         <HStack>

--- a/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
+++ b/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
@@ -112,7 +112,7 @@ const AwardForm = () => {
             placeholder="내용을 입력해주세요."
             id="description"
             register={{ ...register('description') }}
-            errors={errors}
+            error={errors.description}
             autoComplete="off"
             spellCheck="false"
             resize="none"

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -158,7 +158,7 @@ const ProjectForm = () => {
             placeholder="프로젝트에 대한 내용을 입력해주세요."
             id="projectContent"
             register={{ ...register('projectContent') }}
-            errors={errors}
+            error={errors.projectContent}
           />
         </FormControl>
         <FormControl isInvalid={Boolean(errors.projectUrl)}>

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -125,7 +125,7 @@ const TrainingForm = () => {
                   },
                 }),
               }}
-              errors={errors.admissionDate}
+              error={errors.admissionDate}
             />
           </FormControl>
           <FormControl isInvalid={Boolean(errors.graduationDate)}>
@@ -137,7 +137,7 @@ const TrainingForm = () => {
                   min: { value: watch('admissionDate'), message: '유효한 날짜를 입력해 주세요.' },
                 }),
               }}
-              errors={errors.graduationDate}
+              error={errors.graduationDate}
             />
           </FormControl>
         </Flex>
@@ -192,7 +192,7 @@ const TrainingForm = () => {
             placeholder="내용을 입력해주세요."
             id="projectContent"
             register={{ ...register('explanation') }}
-            errors={errors}
+            error={errors.explanation}
           />
         </FormControl>
         <HStack

--- a/src/components/organisms/SignUpHeader/SignUpHeader.tsx
+++ b/src/components/organisms/SignUpHeader/SignUpHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Divider, Flex, Text } from '@chakra-ui/react';
 
 type SignUpHeaderProps = {
   mainMessage: string;
@@ -7,21 +7,27 @@ type SignUpHeaderProps = {
 
 const SignUpHeader = ({ mainMessage, subMessage }: SignUpHeaderProps) => {
   return (
-    <Flex
-      gap={'0.5rem'}
-      direction={'column'}
-      alignSelf={'start'}
-      pl={'2rem'}
-    >
-      <Text
-        color={'gray.900'}
-        fontSize={'1.25rem'}
-        fontWeight={'semibold'}
+    <>
+      <Flex
+        gap={'0.5rem'}
+        direction={'column'}
+        alignSelf={'start'}
+        pl={'2rem'}
       >
-        {mainMessage}
-      </Text>
-      <Text>{subMessage}</Text>
-    </Flex>
+        <Text
+          color={'gray.900'}
+          fontSize={'1.25rem'}
+          fontWeight={'semibold'}
+        >
+          {mainMessage}
+        </Text>
+        <Text>{subMessage}</Text>
+      </Flex>
+      <Divider
+        borderColor={'gray.300'}
+        my={'2rem'}
+      />
+    </>
   );
 };
 

--- a/src/components/organisms/SignUpHeader/SignUpHeader.tsx
+++ b/src/components/organisms/SignUpHeader/SignUpHeader.tsx
@@ -1,4 +1,4 @@
-import { Divider, Flex, Text } from '@chakra-ui/react';
+import { Flex, Text } from '@chakra-ui/react';
 
 type SignUpHeaderProps = {
   mainMessage: string;
@@ -7,27 +7,21 @@ type SignUpHeaderProps = {
 
 const SignUpHeader = ({ mainMessage, subMessage }: SignUpHeaderProps) => {
   return (
-    <>
-      <Flex
-        gap={'0.5rem'}
-        direction={'column'}
-        alignSelf={'start'}
-        pl={'2rem'}
+    <Flex
+      gap={'0.5rem'}
+      direction={'column'}
+      alignSelf={'start'}
+      pl={'2rem'}
+    >
+      <Text
+        color={'gray.900'}
+        fontSize={'1.25rem'}
+        fontWeight={'semibold'}
       >
-        <Text
-          color={'gray.900'}
-          fontSize={'1.25rem'}
-          fontWeight={'semibold'}
-        >
-          {mainMessage}
-        </Text>
-        <Text>{subMessage}</Text>
-      </Flex>
-      <Divider
-        borderColor={'gray.300'}
-        my={'2rem'}
-      />
-    </>
+        {mainMessage}
+      </Text>
+      <Text>{subMessage}</Text>
+    </Flex>
   );
 };
 

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -114,7 +114,7 @@ const CreateEventTemplate = () => {
             <FormControl isInvalid={!!errors.time?.endDate}>
               <FormLabel isRequired={true}>첨삭 종료일</FormLabel>
               <FormDateInput
-                errors={errors.time?.endDate}
+                error={errors.time?.endDate}
                 w={'47.6%'}
                 register={{
                   ...register('time.endDate', {
@@ -138,7 +138,7 @@ const CreateEventTemplate = () => {
                 내용
               </FormLabel>
               <FormTextarea
-                errors={errors}
+                error={errors.info?.content}
                 id="info.content"
                 register={{ ...register('info.content', { required: true }) }}
                 placeholder="이벤트에 대한 상세 내용을 입력해주세요."

--- a/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
+++ b/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, Flex, VStack, Box, Divider } from '@chakra-ui/react';
+import { Image, Text, Flex, VStack, Box } from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
@@ -74,11 +74,6 @@ const SignUpCommonTemplate = ({ onNext }: SignUpCommonTemplateProps) => {
         direction="column"
         alignItems={'center'}
       >
-        <SignUpHeader
-          mainMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.MAIN}
-          subMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.SUB}
-        />
-        <Divider borderColor={'gray.300'} />
         <form onSubmit={handleSubmit(onSubmit)}>
           <VStack
             w={'21.875rem'}

--- a/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
+++ b/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
@@ -74,6 +74,10 @@ const SignUpCommonTemplate = ({ onNext }: SignUpCommonTemplateProps) => {
         direction="column"
         alignItems={'center'}
       >
+        <SignUpHeader
+          mainMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.MAIN}
+          subMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.SUB}
+        />
         <form onSubmit={handleSubmit(onSubmit)}>
           <VStack
             w={'21.875rem'}

--- a/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
+++ b/src/components/templates/SignUpCommonTemplate/SignUpCommonTemplate.tsx
@@ -1,4 +1,4 @@
-import { Image, Text, Flex, VStack, Box } from '@chakra-ui/react';
+import { Image, Text, Flex, VStack, Box, Divider } from '@chakra-ui/react';
 import { useForm } from 'react-hook-form';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
@@ -78,6 +78,7 @@ const SignUpCommonTemplate = ({ onNext }: SignUpCommonTemplateProps) => {
           mainMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.MAIN}
           subMessage={CONSTANTS.SIGNUP_HEADER_MESSAGE.SUB}
         />
+        <Divider borderColor={'gray.300'} />
         <form onSubmit={handleSubmit(onSubmit)}>
           <VStack
             w={'21.875rem'}

--- a/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
+++ b/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
@@ -101,7 +101,7 @@ const SignUpMenteeTemplate = ({ onNext }: SignUpMenteeTemplateProps) => {
                 placeholder="프로필에 표시할 간단한 자기소개를 남겨주세요."
                 id="introduce"
                 register={{ ...register('introduce') }}
-                errors={errors}
+                error={errors.introduce}
                 h={'7.2rem'}
               />
             </FormControl>

--- a/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
+++ b/src/components/templates/SignUpMenteeTemplate/SignUpMenteeTemplate.tsx
@@ -70,9 +70,11 @@ const SignUpMenteeTemplate = ({ onNext }: SignUpMenteeTemplateProps) => {
             spacing={'1.8rem'}
           >
             <FormControl {...FORM_STYLE.control}>
-              <FormLabel {...FORM_STYLE.label}>
+              <FormLabel
+                {...FORM_STYLE.label}
+                subText={CONSTANTS.LABEL_MULTI_SELECTABLE}
+              >
                 관심 직무
-                <MultiSelectText />
               </FormLabel>
               <LabelCheckboxGroup
                 name="interestedPositions"
@@ -81,9 +83,11 @@ const SignUpMenteeTemplate = ({ onNext }: SignUpMenteeTemplateProps) => {
               />
             </FormControl>
             <FormControl {...FORM_STYLE.control}>
-              <FormLabel {...FORM_STYLE.label}>
+              <FormLabel
+                {...FORM_STYLE.label}
+                subText={CONSTANTS.LABEL_MULTI_SELECTABLE}
+              >
                 관심 도메인
-                <MultiSelectText />
               </FormLabel>
               <LabelCheckboxGroup
                 name="interestedFields"
@@ -124,14 +128,3 @@ const SignUpMenteeTemplate = ({ onNext }: SignUpMenteeTemplateProps) => {
 };
 
 export default SignUpMenteeTemplate;
-
-const MultiSelectText = () => {
-  return (
-    <Text
-      color={'gray.500'}
-      fontWeight={'light'}
-    >
-      (여러 개 선택 가능)
-    </Text>
-  );
-};

--- a/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
+++ b/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
@@ -1,5 +1,191 @@
-const SignUpMentorTemplate = () => {
-  return <></>;
+import { Flex, Text, useDisclosure, VStack } from '@chakra-ui/react';
+import { useForm } from 'react-hook-form';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { Button } from '~/components/atoms/Button';
+import { FormLabel } from '~/components/atoms/FormLabel';
+import { FormControl } from '~/components/molecules/FormControl';
+import { FormTextarea } from '~/components/molecules/FormTextarea';
+import { FormTextInput } from '~/components/molecules/FormTextInput';
+import { LabelCheckboxGroup } from '~/components/molecules/LabelCheckboxGroup';
+import { Modal } from '~/components/molecules/Modal';
+import { SignUpHeader } from '~/components/organisms/SignUpHeader';
+import CONSTANTS from '~/constants';
+import { SignUpMentor } from '~/types/signUp';
+
+type FilteredSignUpMentor = Omit<SignUpMentor, 'requiredInfo'>;
+
+type SignUpMentorTemplateProps = {
+  onNext: (values?: FilteredSignUpMentor) => void;
+};
+
+const SignUpMentorTemplate = ({ onNext }: SignUpMentorTemplateProps) => {
+  const {
+    register,
+    control,
+    handleSubmit,
+    formState: { errors, isDirty, isSubmitting },
+  } = useForm<FilteredSignUpMentor>({
+    defaultValues: {
+      experiencedPositions: [],
+      careerContent: '',
+      careerYear: 0,
+      introduce: '',
+    },
+  });
+
+  const onSubmit = (values: FilteredSignUpMentor) => {
+    onNext(values);
+  };
+
+  const handleDelayClick = () => {
+    onNext();
+  };
+
+  const FORM_STYLE = {
+    control: { direction: 'column', spacing: '0.4rem' },
+    label: { fontSize: '0.875rem', my: 0, w: 'auto', display: 'flex', gap: '0.5rem' },
+  } as const;
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <BorderBox
+      hasShadow
+      w={'31.25rem'}
+      py={'3rem'}
+    >
+      <SignUpHeader
+        mainMessage="안녕하세요, 멘토님!"
+        subMessage="멘토 역할로 가입할 경우, 어드민의 승인 후 활동이 가능합니다."
+      />
+      <Flex
+        gap={'2.25rem'}
+        direction="column"
+        px={'2rem'}
+      >
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <VStack
+            w={'full'}
+            spacing={'1.8rem'}
+          >
+            <FormControl
+              isInvalid={!!errors.experiencedPositions}
+              {...FORM_STYLE.control}
+            >
+              <FormLabel
+                isRequired
+                subText={CONSTANTS.LABEL_MULTI_SELECTABLE}
+                {...FORM_STYLE.label}
+              >
+                활동 직무
+              </FormLabel>
+              <LabelCheckboxGroup
+                name="experiencedPositions"
+                control={control}
+                variant={'role'}
+                error={errors.experiencedPositions}
+              />
+            </FormControl>
+            <FormControl
+              isInvalid={Boolean(errors.careerYear)}
+              {...FORM_STYLE.control}
+            >
+              <FormLabel
+                isRequired
+                {...FORM_STYLE.label}
+              >
+                경력 연차
+              </FormLabel>
+              <FormTextInput
+                type="number"
+                id="careerYear"
+                register={{
+                  ...register('careerYear', {
+                    required: '경력 연차를 숫자로 입력해주세요.',
+                    valueAsNumber: true,
+                    validate: (value) => value > 0,
+                  }),
+                }}
+                error={errors.careerYear}
+              />
+            </FormControl>
+            <FormControl
+              isInvalid={Boolean(errors.careerContent)}
+              {...FORM_STYLE.control}
+            >
+              <Flex justifyContent={'space-between'}>
+                <FormLabel
+                  isRequired
+                  {...FORM_STYLE.label}
+                >
+                  경력 사항
+                </FormLabel>
+                <Text
+                  as={'u'}
+                  flexShrink={0}
+                  alignSelf={'start'}
+                  color={'gray.400'}
+                  cursor={'pointer'}
+                  onClick={() => onOpen()}
+                >
+                  예시
+                </Text>
+              </Flex>
+              <CareerContentModal
+                isOpen={isOpen}
+                onClose={onClose}
+              />
+              <FormTextarea
+                placeholder="관련 직무의 경력 사항을 작성해주세요."
+                id="careerContent"
+                register={{
+                  ...register('careerContent', { required: '경력사항을 작성해주세요.' }),
+                }}
+                errors={errors}
+                h={'7.2rem'}
+              />
+            </FormControl>
+            <FormControl {...FORM_STYLE.control}>
+              <FormLabel {...FORM_STYLE.label}>자기소개</FormLabel>
+              <FormTextarea
+                placeholder="프로필에 표시할 간단한 자기소개를 남겨주세요."
+                id="introduce"
+                register={{ ...register('introduce') }}
+                errors={errors}
+                h={'3rem'}
+              />
+            </FormControl>
+            <VStack w={'full'}>
+              <Button
+                onClick={handleDelayClick}
+                variant={'cancel'}
+              >
+                나중에 작성하기
+              </Button>
+              <Button
+                type="submit"
+                isDisabled={!isDirty}
+                isLoading={isSubmitting}
+              >
+                완료하기
+              </Button>
+            </VStack>
+          </VStack>
+        </form>
+      </Flex>
+    </BorderBox>
+  );
 };
 
 export default SignUpMentorTemplate;
+
+const CareerContentModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
+  return (
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size={'lg'}
+    >
+      여기에 경력 사항에 대한 예시가 작성됩니다.
+    </Modal>
+  );
+};

--- a/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
+++ b/src/components/templates/SignUpMentorTemplate/SignUpMentorTemplate.tsx
@@ -185,7 +185,11 @@ const CareerContentModal = ({ isOpen, onClose }: { isOpen: boolean; onClose: () 
       onClose={onClose}
       size={'lg'}
     >
-      여기에 경력 사항에 대한 예시가 작성됩니다.
+      <Text whiteSpace={'pre-line'}>
+        {`현) ▵▵▵ 시니어 풀스택 개발자 재직 중
+        전) ◻◻◻ 프론트엔드 개발자 5년 근무
+        전) ⎔⎔⎔ 인턴 프론트엔드 개발자 2년 근무`}
+      </Text>
     </Modal>
   );
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -12,6 +12,7 @@ const CONSTANTS = {
     MAIN: '이력, 써에 오신 것을 환영합니다!',
     SUB: '간단한 개인 정보를 입력하고 바로 시작하세요.',
   },
+  LABEL_MULTI_SELECTABLE: '(여러 개 선택 가능)',
 };
 
 export default CONSTANTS;

--- a/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
@@ -1,36 +1,13 @@
 import { Flex } from '@chakra-ui/react';
 import { MentorProfile } from '~/components/molecules/MentorProfile';
 import { EventDetail } from '~/components/organisms/EventDetail';
+import { useGetEventDetail } from '~/queries/event/details/useGetEventDetail';
 import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
-import { Position } from '~/types/position';
-
-const DUMMY_DATA = {
-  event: {
-    info: {
-      title: 'title_b21dc40438ed',
-      content: 'dlfjgrp',
-      maximumCount: 0,
-      currentApplicantCount: 0,
-      positions: ['FRONT'] as Position[],
-      timeInfo: {
-        openDateTime: '2023-11-07 17:48:51',
-        closeDateTime: '2023-11-07 17:48:51',
-        endDate: '2023-11-07 17:48:51',
-      },
-    },
-    resumes: [
-      {
-        resumeId: 0,
-        menteeName: 'menteeName_a5382713f0d2',
-        resumeTitle: 'resumeTitle_3f57dbe0891f',
-        progressStatus: 'progressStatus_ad4597f425d4',
-      },
-    ],
-  },
-};
 
 const EventDetailPage = () => {
+  //Todo: 이벤트 리스트가 완성되면 "1" 지우기
   const { data: mentor } = useGetMentorDetail({ mentorId: '1' });
+  const { data: event } = useGetEventDetail({ eventId: '1' });
 
   return (
     <Flex
@@ -39,11 +16,11 @@ const EventDetailPage = () => {
     >
       <MentorProfile
         mentor={mentor}
-        event={DUMMY_DATA.event}
+        event={event}
       />
       <EventDetail
         mentor={mentor}
-        event={DUMMY_DATA.event}
+        event={event}
       />
     </Flex>
   );

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -11,7 +11,7 @@ const SignUpPage = () => {
   const [step, setStep] = useState<Step>('COMMON');
   const [commonData, setCommonData] = useState<SignUpCommon<SignUpRole>>();
   const [menteeData, setMenteeData] = useState<Omit<SignUpMentee, 'requiredInfo'>>();
-  const [mentorData, setMentorData] = useState<SignUpMentor>();
+  const [mentorData, setMentorData] = useState<Omit<SignUpMentor, 'requiredInfo'>>();
   /*FIXME - 사용하지 않는 변수 lint에러 방지용 로그 .. 삭제 필요! */
   console.log(commonData, menteeData, setMenteeData, mentorData, setMentorData);
   return (
@@ -25,7 +25,16 @@ const SignUpPage = () => {
         />
       )}
       {/**TODO - onNext에 각각 menteeData, mentorData를 바디로 api 호출 (commonData 삽입해서) */}
-      {step === 'ROLE_PENDING' && <SignUpMentorTemplate />}
+      {step === 'ROLE_PENDING' && (
+        <SignUpMentorTemplate
+          onNext={(data) => {
+            setStep('COMPLETE');
+            if (data) {
+              setMentorData(data);
+            }
+          }}
+        />
+      )}
       {step === 'ROLE_MENTEE' && (
         <SignUpMenteeTemplate
           onNext={(data) => {

--- a/src/queries/event/details/useGetEventDetail.ts
+++ b/src/queries/event/details/useGetEventDetail.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { GetEventDetail, getEventDetail } from '~/api/event/details/getEventDetail';
+
+export const useGetEventDetail = ({ eventId }: GetEventDetail) => {
+  return useSuspenseQuery({
+    queryKey: ['getEventDetail'],
+    queryFn: () => getEventDetail({ eventId }),
+  });
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
https://github.com/resumeme/Frontend/assets/91667853/ce514ad9-ea15-4a22-a8e7-be8661884ff0

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 멘토 가입 페이지를 구현했습니다.
- LabelCheckboxGroup에 에러메시지를 추가해줬습니다.
  - Controller를 사용하고 있어 다른 인풋들과 달리 errorMessage를 props로 직접 전달해야 합니다.
- FormLabel에 서브 텍스트를 추가할 수 있도록 했습니다.
  - `subText`: 텍스트 내용
  - `subTextDirection`: 정렬 방향 (row | column)
<br>  


**- 아래 파일만 보시면 됩니다.**
  - src/constants/index.ts
  - FormLabel.tsx
  - LabelCheckboxGroup.tsx
  - SignUpMentorTemplate.tsx
  - SignUpPage.tsx
  
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
슬랙에서 말씀드렸듯이 isDirty가 제대로 작동하려면 defaultValue가 필요한데, 경력 연차의 경우 숫자를 0으로 기본값을 부여하고 있어 처음에 0이 입력된 상태로 뜹니다. 

  ➡️ 이걸 사용자가 지우면 아무것도 입력이 되지 않은 상태임에도 defaultValue와 다르다고 판단
  ➡️ isDirty가 true가 됨
  ➡️ 완료 버튼 disabled가 풀림

이런 문제가 있네요..

## 🔎 PR포인트 및 궁금한 점
- 경력사항에 대한 예시를 임의로 끄적여놓긴 했는데, 다른 좋은 문구 있다면 추천받습니다!