### PR TITLE
Gmmq 346 style: 이력서 상세 페이지 - 교육 UI 구현

### DIFF
--- a/src/components/organisms/ResumeDetails/TrainingDetails.tsx
+++ b/src/components/organisms/ResumeDetails/TrainingDetails.tsx
@@ -1,5 +1,7 @@
+import { Divider, Flex, Heading, Text } from '@chakra-ui/react';
+import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import { Training } from '~/types/training';
 
 const TraningDetails = ({ data }: { data: Training[] }) => {
@@ -9,29 +11,131 @@ const TraningDetails = ({ data }: { data: Training[] }) => {
   return (
     <>
       {data?.map(
-        ({
-          organization,
-          major,
-          degree,
-          admissionDate,
-          graduationDate,
-          gpa,
-          maxGpa,
-          explanation,
-        }: Training) => {
+        (
+          {
+            organization,
+            major,
+            degree,
+            admissionDate,
+            graduationDate,
+            gpa,
+            maxGpa,
+            explanation,
+          }: Training,
+          i,
+        ) => {
           return (
-            <BorderBox
-              key={uuidv4()}
-              w={'100%'}
-            >
-              <div>{organization}</div>
-              <div>{major}</div>
-              <div>{degree}</div>
-              <div>{admissionDate}</div>
-              <div>{graduationDate}</div>
-              <div>{`${gpa} / ${maxGpa}`}</div>
-              <div>{explanation}</div>
-            </BorderBox>
+            <React.Fragment key={uuidv4()}>
+              {i > 0 && (
+                <Divider
+                  key={i}
+                  my={'3rem'}
+                  borderColor={'gray.300'}
+                />
+              )}
+              <Flex>
+                <Flex flex={1}>
+                  <Flex direction={'column'}>
+                    <Flex
+                      justify={'start'}
+                      align={'center'}
+                      gap={2}
+                    >
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        h={'fit-content'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {admissionDate}
+                      </Label>
+                      <Text display={'inline-block'}>-</Text>
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {graduationDate ?? '진행중'}
+                      </Label>
+                    </Flex>
+                  </Flex>
+                </Flex>
+                <Flex
+                  mt={'1%'}
+                  flex={2}
+                  direction={'column'}
+                >
+                  <Flex
+                    direction={'column'}
+                    width={'full'}
+                    gap={5}
+                  >
+                    <Heading
+                      fontSize={'xl'}
+                      fontWeight={'bold'}
+                      color={'gray.800'}
+                    >
+                      {organization}
+                    </Heading>
+                    <Flex
+                      gap={2}
+                      direction={'column'}
+                    >
+                      <Flex
+                        gap={5}
+                        align={'center'}
+                      >
+                        <Text
+                          fontWeight={'medium'}
+                          color={'gray.800'}
+                        >
+                          {major}
+                        </Text>
+                        <Divider
+                          orientation="vertical"
+                          borderColor={'gray.400'}
+                          h={'1rem'}
+                        />
+                        <Text
+                          fontWeight={'medium'}
+                          color={'gray.800'}
+                        >
+                          {degree}
+                        </Text>
+                      </Flex>
+                      {gpa && maxGpa && (
+                        <Flex
+                          gap={5}
+                          align={'center'}
+                        >
+                          <Text
+                            fontSize={'md'}
+                            color={'gray.800'}
+                            fontWeight={'semibold'}
+                          >
+                            평가
+                          </Text>
+                          <Text as={'span'}>
+                            {gpa} / {maxGpa}
+                          </Text>
+                        </Flex>
+                      )}
+                    </Flex>
+                    {explanation && (
+                      <Flex
+                        flexWrap={'wrap'}
+                        wordBreak={'break-word'}
+                        mt={2}
+                      >
+                        <Text>{explanation}</Text>
+                      </Flex>
+                    )}
+                  </Flex>
+                </Flex>
+              </Flex>
+            </React.Fragment>
           );
         },
       )}

--- a/src/components/organisms/ResumeDetails/index.ts
+++ b/src/components/organisms/ResumeDetails/index.ts
@@ -3,11 +3,11 @@ import AwardDetails from './AwardDetails';
 import CareerDetails from './CareerDetails';
 import LanguageDetails from './LanguageDetails';
 import ProjectDetails from './ProjectDetails';
-import TraningDetails from './TrainingDetails';
+import TrainingDetails from './TrainingDetails';
 
 export {
   CareerDetails,
-  TraningDetails,
+  TrainingDetails,
   LanguageDetails,
   ProjectDetails,
   AwardDetails,

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -10,7 +10,7 @@ import { ProjectForm } from '~/components/organisms/ResumeCategoryProject';
 import { TrainingForm } from '~/components/organisms/ResumeCategoryTraining';
 import {
   CareerDetails,
-  TraningDetails,
+  TrainingDetails,
   LanguageDetails,
   ProjectDetails,
   AwardDetails,
@@ -67,7 +67,7 @@ const EditResumeTemplate = () => {
         </ResumeCategory>
         <ResumeCategory
           categoryType="교육"
-          detailsComponent={<TraningDetails data={trainingsData} />}
+          detailsComponent={<TrainingDetails data={trainingsData} />}
         >
           <TrainingForm />
         </ResumeCategory>

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -3,8 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
-import { CareerDetails } from '~/components/organisms/ResumeDetails';
-import TrainingDetails from '~/components/organisms/ResumeDetails/TrainingDetails';
+import { CareerDetails, ProjectDetails } from '~/components/organisms/ResumeDetails';
 
 const DUMMY_DATA = {
   userInfo: {
@@ -92,6 +91,33 @@ const CAREER_DUMMY_DATA = [
     careerStartDate: '2000-00-00',
     endDate: '2000-00-01',
     careerContent: '어쩌구 저쩌구',
+  },
+];
+
+const PROJECT_DUMMY_DATA = [
+  {
+    projectName: '이력,써',
+    productionYear: 2023,
+    isTeam: true,
+    teamMembers: '6명(프론트엔드 3명, 백엔드 3명)',
+    skills: ['TypeScript', 'React.js', 'Chakra-UI', 'Tanstack-Qeury', 'React-Hook-Form'],
+    projectContent: '와우 지금 만들고 있는거에요 ㅋ 이력서 첨삭 서비스입니다. 2달 걸림',
+    projectUrl: 'https://abcd.efg',
+  },
+  {
+    projectName: 'TMI Homers',
+    productionYear: 2023,
+    isTeam: true,
+    teamMembers: '5명(프론트엔드 5명)',
+    skills: ['TypeScript', 'React.js', 'TailwindCSS', 'Tanstack-Qeury', 'React-Hook-Form'],
+    projectContent: '와우 지지난달에 만든거에요 1달걸림 ㅋ ',
+    projectUrl: 'https://abcd.efg',
+  },
+  {
+    projectName: '테스트 프로젝트1',
+    productionYear: 2021,
+    isTeam: false,
+    projectUrl: 'https://hijk.com',
   },
 ];
 
@@ -260,7 +286,7 @@ const ResumeDetailTemplate = () => {
             {/* NOTE LowerPart - 하단부 - 업무경험 UI */}
             <Flex
               direction={'column'}
-              gap={1}
+              gap={'4rem'}
             >
               <Box>
                 <Text
@@ -277,6 +303,23 @@ const ResumeDetailTemplate = () => {
                   gap={10}
                 >
                   <CareerDetails data={CAREER_DUMMY_DATA} />
+                </BorderBox>
+              </Box>
+              <Box>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  프로젝트
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  p={7}
+                  gap={10}
+                >
+                  <ProjectDetails data={PROJECT_DUMMY_DATA} />
                 </BorderBox>
               </Box>
               <Box>

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -4,6 +4,7 @@ import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
 import { CareerDetails } from '~/components/organisms/ResumeDetails';
+import TrainingDetails from '~/components/organisms/ResumeDetails/TrainingDetails';
 
 const DUMMY_DATA = {
   userInfo: {
@@ -91,6 +92,25 @@ const CAREER_DUMMY_DATA = [
     careerStartDate: '2000-00-00',
     endDate: '2000-00-01',
     careerContent: '어쩌구 저쩌구',
+  },
+];
+
+const TRAINING_DUMMY_DATA = [
+  {
+    organization: '그쪽대학교',
+    major: '컴퓨터공학',
+    degree: '학사',
+    admissionDate: '2000-00-00',
+    graduationDate: '2000-00-00',
+    gpa: 4.5,
+    maxGpa: 4.5,
+    explanation: '너는 나를 존중해야 한다. 나는 그쪽대를 수석으로 입학하였으며...[더보기]',
+  },
+  {
+    organization: '그쪽대학원',
+    major: '컴퓨터공학',
+    degree: '홍박사',
+    admissionDate: '2000-00-00',
   },
 ];
 
@@ -257,6 +277,23 @@ const ResumeDetailTemplate = () => {
                   gap={10}
                 >
                   <CareerDetails data={CAREER_DUMMY_DATA} />
+                </BorderBox>
+              </Box>
+              <Box>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  교육
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  p={7}
+                  gap={10}
+                >
+                  <TrainingDetails data={TRAINING_DUMMY_DATA} />
                 </BorderBox>
               </Box>
             </Flex>

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -3,10 +3,10 @@ type Training = {
   major: string;
   degree: string;
   admissionDate: string;
-  graduationDate: string;
-  gpa: number;
-  maxGpa: number;
-  explanation: string;
+  graduationDate?: string;
+  gpa?: number;
+  maxGpa?: number;
+  explanation?: string;
 };
 
 export type { Training };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/59f2a4cc-bc65-452e-914f-ab6b9de5a400)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 작성 페이지의 교육 UI를 구현하였습니다.
- **ResumeDetails의 `TraningDetails` => `TrainingDetails`로 오타 수정하였습니다.**
- type의 `Training.ts` 파일에서 선택 옵션 지정하였습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
