### PR TITLE
Gmmq 349 style: 이력서 상세 페이지 - 활동, 외국어 UI 구현 및 목업 데이터 분리

### DIFF
--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -24,7 +24,6 @@ const ActivityDetails = ({ data }: { data: Activity[] }) => {
               )}
               <Flex key={uuidv4()}>
                 <Flex flex={1}>
-                  {/* NOTE 기간 및 날짜 데이터 */}
                   <Flex direction={'column'}>
                     <Flex
                       justify={'start'}

--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -22,7 +22,7 @@ const ActivityDetails = ({ data }: { data: Activity[] }) => {
                   borderColor={'gray.300'}
                 />
               )}
-              <Flex key={uuidv4()}>
+              <Flex>
                 <Flex flex={1}>
                   <Flex direction={'column'}>
                     <Flex

--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -1,5 +1,8 @@
+import { Flex, Text, Heading, Divider, Link, Icon } from '@chakra-ui/react';
+import React from 'react';
+import { HiLink } from 'react-icons/hi';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import { Activity } from '~/types/activity';
 
 const ActivityDetails = ({ data }: { data: Activity[] }) => {
@@ -8,20 +11,93 @@ const ActivityDetails = ({ data }: { data: Activity[] }) => {
   }
   return (
     <>
-      {data?.map((company: Activity) => {
-        return (
-          <BorderBox
-            key={uuidv4()}
-            w={'100%'}
-          >
-            <div>{company.activityName}</div>
-            <div>{company.startDate}</div>
-            {!company.inProgress && <div>{company.endDate}</div>}
-            <a>{company.link}</a>
-            <div>{company.description}</div>
-          </BorderBox>
-        );
-      })}
+      {data?.map(
+        ({ activityName, startDate, endDate, inProgress, link, description }: Activity, index) => {
+          return (
+            <React.Fragment key={uuidv4()}>
+              {index > 0 && (
+                <Divider
+                  key={index}
+                  my={'3rem'}
+                  borderColor={'gray.300'}
+                />
+              )}
+              <Flex key={uuidv4()}>
+                <Flex flex={1}>
+                  {/* NOTE 기간 및 날짜 데이터 */}
+                  <Flex direction={'column'}>
+                    <Flex
+                      justify={'start'}
+                      align={'center'}
+                      gap={2}
+                    >
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        h={'fit-content'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {startDate}
+                      </Label>
+                      <Text display={'inline-block'}>-</Text>
+                      <Label
+                        bg={'gray.300'}
+                        color={'gray.700'}
+                        py={0}
+                        fontWeight={'medium'}
+                      >
+                        {inProgress ? '진행중' : endDate}
+                      </Label>
+                    </Flex>
+                  </Flex>
+                </Flex>
+                <Flex
+                  mt={'1%'}
+                  flex={2}
+                  direction={'column'}
+                >
+                  <Flex
+                    direction={'column'}
+                    width={'full'}
+                    gap={2}
+                  >
+                    <Heading
+                      fontSize={'xl'}
+                      fontWeight={'bold'}
+                      color={'gray.800'}
+                    >
+                      {activityName}
+                    </Heading>
+                    <Flex
+                      direction={'column'}
+                      gap={2}
+                    >
+                      {description && <Text mt={5}>{description}</Text>}
+                      {link && (
+                        <Flex
+                          mt={5}
+                          gap={3}
+                          align={'center'}
+                        >
+                          <Icon as={HiLink} />
+                          <Link
+                            isExternal
+                            fontSize={'sm'}
+                            color={'primary.900'}
+                          >
+                            {link}
+                          </Link>
+                        </Flex>
+                      )}
+                    </Flex>
+                  </Flex>
+                </Flex>
+              </Flex>
+            </React.Fragment>
+          );
+        },
+      )}
     </>
   );
 };

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -33,9 +33,8 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
                   borderColor={'gray.300'}
                 />
               )}
-              <Flex key={uuidv4()}>
+              <Flex>
                 <Flex flex={1}>
-                  {/* NOTE 기간 및 날짜 데이터 */}
                   <Flex direction={'column'}>
                     <Flex
                       justify={'start'}
@@ -63,8 +62,6 @@ const CareerDetails = ({ data }: { data: Career[] }) => {
                     </Flex>
                   </Flex>
                 </Flex>
-
-                {/* NOTE 데이터 내용 */}
                 <Flex
                   mt={'1%'}
                   flex={2}

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -27,7 +27,7 @@ const LanguageDetails = ({ data }: { data: Language[] }) => {
                 borderColor={'gray.300'}
               />
             )}
-            <Flex key={uuidv4()}>
+            <Flex>
               <Flex flex={1}>
                 <Label
                   bg={'gray.300'}

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -1,21 +1,72 @@
+import { Flex, Text, Divider, Heading } from '@chakra-ui/react';
+import React from 'react';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import { Language } from '~/types/language';
+
+/* TODO  
+  기본으로 언어 카테고리 제시하기 (영어, 일본어, 중국어, 기타(입력받기))
+  같은 카테고리의 언어일 경우 블록 내부의 같은 영역에 보이게 하기
+  언어 카테고리별 색상 테마를 상수로 적용해서 각 라벨의 색상 지정해주기?
+*/
 
 const LanguageDetails = ({ data }: { data: Language[] }) => {
   if (!data) {
     return;
   }
+
   return (
     <>
-      {data?.map((language: Language) => {
+      {data?.map(({ language, examName, scoreOrGrade }: Language, index) => {
         return (
-          <BorderBox
-            key={uuidv4()}
-            w={'100%'}
-          >
-            <div>{language.language}</div>
-          </BorderBox>
+          <React.Fragment key={uuidv4()}>
+            {index > 0 && (
+              <Divider
+                key={index}
+                my={'2rem'}
+                borderColor={'gray.300'}
+              />
+            )}
+            <Flex key={uuidv4()}>
+              <Flex flex={1}>
+                <Label
+                  bg={'gray.300'}
+                  color={'gray.700'}
+                  h={'fit-content'}
+                  fontSize={'md'}
+                  py={0}
+                  fontWeight={'semibold'}
+                >
+                  {language}
+                </Label>
+              </Flex>
+              <Flex
+                mt={'1%'}
+                flex={2}
+                direction={'column'}
+              >
+                <Flex
+                  width={'full'}
+                  align={'flex-end'}
+                  gap={5}
+                >
+                  <Heading
+                    fontSize={'xl'}
+                    fontWeight={'bold'}
+                    color={'gray.800'}
+                  >
+                    {examName}
+                  </Heading>
+                  <Divider
+                    orientation="vertical"
+                    borderColor={'gray.400'}
+                    h={'full'}
+                  />
+                  <Text fontWeight={'regular'}>{scoreOrGrade}</Text>
+                </Flex>
+              </Flex>
+            </Flex>
+          </React.Fragment>
         );
       })}
     </>

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -33,7 +33,7 @@ const ProjectDetails = ({ data }: { data: Project[] }) => {
                   borderColor={'gray.300'}
                 />
               )}
-              <Flex key={uuidv4()}>
+              <Flex>
                 <Flex flex={1}>
                   <Flex direction={'column'}>
                     <Flex

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -122,6 +122,7 @@ const ProjectDetails = ({ data }: { data: Project[] }) => {
                         <Icon as={HiLink} />
                         <Link
                           isExternal
+                          href={projectUrl}
                           fontSize={'sm'}
                           color={'primary.900'}
                         >

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetail.const.ts
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetail.const.ts
@@ -1,0 +1,194 @@
+// DUMMY DATA
+
+export const data = {
+  info: {
+    userInfo: {
+      name: '신동호',
+      phoneNumber: '010-0000-0000',
+    },
+    resume: {
+      id: '1234',
+      resumeTitle: '사용자를 생각하는 프론트엔드 개발자, 신동호입니다.',
+    },
+    basicInfo: {
+      position: '프론트엔드 개발자',
+      skills: ['TypeScript', 'JavaScript', 'React.js', 'Next.js', 'Python', 'Git', 'CSS', 'HTML5'],
+      introduce:
+        '안녕하세요. 사용자를 생각하는 프론트엔드 개발자 신동호입니다. 100글자를 채울 필요는 없지만, 일단 길게 써야 테스트할 수 있습니다.',
+    },
+    referenceLinks: [
+      {
+        linkType: 'github',
+        url: 'https://github.com/khakhiD',
+      },
+      {
+        linkType: 'blog',
+        url: 'https://khakhidiggin-log.vercel.app',
+      },
+    ],
+  },
+  career: [
+    {
+      companyName: '아몬드빼빼로',
+      position: '주니어 프론트엔드 개발자',
+      isCurrentlyEmployed: true,
+      skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
+      duties: [
+        {
+          title: '중요한 업무업무',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+        {
+          title:
+            '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 해야데이엄? 더 길게 한다 더 길게',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+        {
+          title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+      ],
+      careerStartDate: '2000-00-00',
+      endDate: '2000-00-01',
+      careerContent: '어쩌구 저쩌구',
+    },
+    {
+      companyName: '아몬드빼빼로',
+      position: '주니어 프론트엔드 개발자',
+      isCurrentlyEmployed: true,
+      skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
+      duties: [
+        {
+          title: '중요한 업무업무',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+        {
+          title: '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 할려궁?',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+        {
+          title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
+          description: '중요한 업무를 했다 와 힘들었따',
+          startDate: '2000-00-00',
+          endDate: '2000-00-01',
+        },
+      ],
+      careerStartDate: '2000-00-00',
+      endDate: '2000-00-01',
+      careerContent: '어쩌구 저쩌구',
+    },
+  ],
+  project: [
+    {
+      projectName: '이력,써',
+      productionYear: 2023,
+      isTeam: true,
+      teamMembers: '6명(프론트엔드 3명, 백엔드 3명)',
+      skills: ['TypeScript', 'React.js', 'Chakra-UI', 'Tanstack-Qeury', 'React-Hook-Form'],
+      projectContent: '와우 지금 만들고 있는거에요 ㅋ 이력서 첨삭 서비스입니다. 2달 걸림',
+      projectUrl: 'https://abcd.efg',
+    },
+    {
+      projectName: 'TMI Homers',
+      productionYear: 2023,
+      isTeam: true,
+      teamMembers: '5명(프론트엔드 5명)',
+      skills: ['TypeScript', 'React.js', 'TailwindCSS', 'Tanstack-Qeury', 'React-Hook-Form'],
+      projectContent: '와우 지지난달에 만든거에요 1달걸림 ㅋ ',
+      projectUrl: 'https://abcd.efg',
+    },
+    {
+      projectName: '테스트 프로젝트1',
+      productionYear: 2021,
+      isTeam: false,
+      projectUrl: 'https://hijk.com',
+    },
+  ],
+  award: [
+    {
+      certificationTitle: '정보처리기사',
+      acquisitionDate: '2000-00-00',
+      issuingAuthority: '한국산업인력공단',
+      link: 'https://abcd.efg',
+      description: '하하 정처기를 땄다우',
+    },
+    {
+      certificationTitle: '호그와트 마법사 1급',
+      acquisitionDate: '2000-00-00',
+      issuingAuthority: '호그와트',
+      link: 'https://abcd.efg',
+    },
+    {
+      certificationTitle: '오타쿠',
+    },
+  ],
+  training: [
+    {
+      organization: '그쪽대학교',
+      major: '컴퓨터공학',
+      degree: '학사',
+      admissionDate: '2000-00-00',
+      graduationDate: '2000-00-00',
+      gpa: 4.5,
+      maxGpa: 4.5,
+      explanation: '너는 나를 존중해야 한다. 나는 그쪽대를 수석으로 입학하였으며...[더보기]',
+    },
+    {
+      organization: '그쪽대학원',
+      major: '컴퓨터공학',
+      degree: '홍박사',
+      admissionDate: '2000-00-00',
+    },
+  ],
+  activity: [
+    {
+      activityName: '블로그 활동',
+      startDate: '2000-00-00',
+      endDate: '',
+      inProgress: true,
+      link: 'https://khakidiggin-log.vercel.app',
+      description: '열심히 활동했읍니다.',
+    },
+    {
+      activityName: '동아리 활동',
+      startDate: '2000-00-00',
+      endDate: '2000-00-00',
+      inProgress: false,
+      link: 'https://khakidiggin-log.vercel.app',
+      description: '열심히 활동했읍니다.',
+    },
+    {
+      activityName: '테스트 활동',
+      startDate: '2000-00-00',
+      endDate: '2000-00-00',
+      inProgress: false,
+    },
+  ],
+  language: [
+    {
+      language: '영어',
+      examName: '토익',
+      scoreOrGrade: '100점',
+    },
+    {
+      language: '영국어',
+      examName: '영국 토익',
+      scoreOrGrade: '100점',
+    },
+    {
+      language: '미국어',
+      examName: '미국 토익',
+      scoreOrGrade: '100점',
+    },
+  ],
+};

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetail.const.ts
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetail.const.ts
@@ -177,18 +177,18 @@ export const data = {
   language: [
     {
       language: '영어',
-      examName: '토익',
-      scoreOrGrade: '100점',
+      examName: 'TOEIC',
+      scoreOrGrade: '900점',
     },
     {
-      language: '영국어',
-      examName: '영국 토익',
-      scoreOrGrade: '100점',
+      language: '중국어',
+      examName: 'HSK',
+      scoreOrGrade: '4급',
     },
     {
-      language: '미국어',
-      examName: '미국 토익',
-      scoreOrGrade: '100점',
+      language: '일본어',
+      examName: 'JLPT',
+      scoreOrGrade: 'N1',
     },
   ],
 };

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -7,6 +7,7 @@ import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
 import {
   ActivityDetails,
   CareerDetails,
+  LanguageDetails,
   ProjectDetails,
 } from '~/components/organisms/ResumeDetails';
 
@@ -169,8 +170,8 @@ const ResumeDetailTemplate = () => {
                 </Text>
                 <BorderBox
                   w={'100%'}
-                  p={7}
-                  gap={10}
+                  px={7}
+                  py={10}
                 >
                   <CareerDetails data={data.career} />
                 </BorderBox>
@@ -186,8 +187,8 @@ const ResumeDetailTemplate = () => {
                 </Text>
                 <BorderBox
                   w={'100%'}
-                  p={7}
-                  gap={10}
+                  px={7}
+                  py={10}
                 >
                   <ProjectDetails data={data.project} />
                 </BorderBox>
@@ -203,10 +204,28 @@ const ResumeDetailTemplate = () => {
                 </Text>
                 <BorderBox
                   w={'100%'}
-                  p={7}
-                  gap={10}
+                  px={7}
+                  py={10}
                 >
                   <ActivityDetails data={data.activity} />
+                </BorderBox>
+              </Box>
+              <Box>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  외국어
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  px={7}
+                  py={10}
+                  gap={10}
+                >
+                  <LanguageDetails data={data.language} />
                 </BorderBox>
               </Box>
             </Flex>

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -1,125 +1,14 @@
 import { PhoneIcon } from '@chakra-ui/icons';
 import { Box, Flex, Text } from '@chakra-ui/react';
+import { data } from './ResumeDetail.const';
 import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
-import { CareerDetails, ProjectDetails } from '~/components/organisms/ResumeDetails';
-
-const DUMMY_DATA = {
-  userInfo: {
-    name: '신동호',
-    phoneNumber: '010-0000-0000',
-  },
-  resume: {
-    id: '1234',
-    resumeTitle: '사용자를 생각하는 프론트엔드 개발자, 신동호입니다.',
-  },
-  basicInfo: {
-    position: '프론트엔드 개발자',
-    skills: ['TypeScript', 'JavaScript', 'React.js', 'Next.js', 'Python', 'Git', 'CSS', 'HTML5'],
-    introduce:
-      '안녕하세요. 사용자를 생각하는 프론트엔드 개발자 신동호입니다. 100글자를 채울 필요는 없지만, 일단 길게 써야 테스트할 수 있습니다.',
-  },
-  referenceLinks: [
-    {
-      linkType: 'github',
-      url: 'https://github.com/khakhiD',
-    },
-    {
-      linkType: 'blog',
-      url: 'https://khakhidiggin-log.vercel.app',
-    },
-  ],
-};
-
-const CAREER_DUMMY_DATA = [
-  {
-    companyName: '아몬드빼빼로',
-    position: '주니어 프론트엔드 개발자',
-    isCurrentlyEmployed: true,
-    skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
-    duties: [
-      {
-        title: '중요한 업무업무',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-      {
-        title:
-          '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 해야데이엄? 더 길게 한다 더 길게',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-      {
-        title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-    ],
-    careerStartDate: '2000-00-00',
-    endDate: '2000-00-01',
-    careerContent: '어쩌구 저쩌구',
-  },
-  {
-    companyName: '아몬드빼빼로',
-    position: '주니어 프론트엔드 개발자',
-    isCurrentlyEmployed: true,
-    skills: ['TypeScript', 'React.js', 'Git', 'Github', 'ChakraUI', 'react-hook-form', 'vite'],
-    duties: [
-      {
-        title: '중요한 업무업무',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-      {
-        title: '이력서 상세 페이지 UI 개발 근데 이게 엄청 길어지면 어떡꼐 할려궁?',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-      {
-        title: '주요 업무 (ex. 프로그래머스 데브코스 수강 페이지 신설)',
-        description: '중요한 업무를 했다 와 힘들었따',
-        startDate: '2000-00-00',
-        endDate: '2000-00-01',
-      },
-    ],
-    careerStartDate: '2000-00-00',
-    endDate: '2000-00-01',
-    careerContent: '어쩌구 저쩌구',
-  },
-];
-
-const PROJECT_DUMMY_DATA = [
-  {
-    projectName: '이력,써',
-    productionYear: 2023,
-    isTeam: true,
-    teamMembers: '6명(프론트엔드 3명, 백엔드 3명)',
-    skills: ['TypeScript', 'React.js', 'Chakra-UI', 'Tanstack-Qeury', 'React-Hook-Form'],
-    projectContent: '와우 지금 만들고 있는거에요 ㅋ 이력서 첨삭 서비스입니다. 2달 걸림',
-    projectUrl: 'https://abcd.efg',
-  },
-  {
-    projectName: 'TMI Homers',
-    productionYear: 2023,
-    isTeam: true,
-    teamMembers: '5명(프론트엔드 5명)',
-    skills: ['TypeScript', 'React.js', 'TailwindCSS', 'Tanstack-Qeury', 'React-Hook-Form'],
-    projectContent: '와우 지지난달에 만든거에요 1달걸림 ㅋ ',
-    projectUrl: 'https://abcd.efg',
-  },
-  {
-    projectName: '테스트 프로젝트1',
-    productionYear: 2021,
-    isTeam: false,
-    projectUrl: 'https://hijk.com',
-  },
-];
+import {
+  ActivityDetails,
+  CareerDetails,
+  ProjectDetails,
+} from '~/components/organisms/ResumeDetails';
 
 const ResumeDetailTemplate = () => {
   return (
@@ -136,7 +25,7 @@ const ResumeDetailTemplate = () => {
           fontWeight={'bold'}
           color={'gray.800'}
         >
-          {DUMMY_DATA.resume.resumeTitle}
+          {data.info.resume.resumeTitle}
         </Text>
       </Box>
       {/* NOTE UpperPart 시작 */}
@@ -171,7 +60,7 @@ const ResumeDetailTemplate = () => {
                   fontWeight={'bold'}
                   color={'gray.900'}
                 >
-                  {DUMMY_DATA.userInfo.name}
+                  {data.info.userInfo.name}
                 </Text>
                 <Label
                   width={'fit-content'}
@@ -180,14 +69,14 @@ const ResumeDetailTemplate = () => {
                   color={'gray.100'}
                   px={5}
                 >
-                  {DUMMY_DATA.basicInfo.position}
+                  {data.info.basicInfo.position}
                 </Label>
                 <Flex
                   gap={4}
                   align={'center'}
                 >
                   <PhoneIcon />
-                  <Text>{DUMMY_DATA.userInfo.phoneNumber}</Text>
+                  <Text>{data.info.userInfo.phoneNumber}</Text>
                 </Flex>
               </Flex>
               <Flex
@@ -197,7 +86,7 @@ const ResumeDetailTemplate = () => {
                 width={'100%'}
               >
                 {/* FIXME type 관련 에러가 ReferenceLinkBox에서 발생! */}
-                {DUMMY_DATA?.referenceLinks.map((link, i) => (
+                {data.info?.referenceLinks.map((link, i) => (
                   <ReferenceLinkBox
                     key={i}
                     type="github"
@@ -233,7 +122,7 @@ const ResumeDetailTemplate = () => {
                   justify={'flex-end'}
                   flexWrap={'wrap'}
                 >
-                  {DUMMY_DATA.basicInfo.skills?.map((skill, i) => (
+                  {data.info.basicInfo.skills?.map((skill, i) => (
                     <Label
                       key={i}
                       bg={'gray.300'}
@@ -256,7 +145,7 @@ const ResumeDetailTemplate = () => {
               fontSize={'sm'}
               fontWeight={'medium'}
             >
-              <Text>{DUMMY_DATA.basicInfo.introduce}</Text>
+              <Text>{data.info.basicInfo.introduce}</Text>
             </BorderBox>
           </Flex>
           {/* NOTE LowerPart - 하단부 UI */}
@@ -283,7 +172,7 @@ const ResumeDetailTemplate = () => {
                   p={7}
                   gap={10}
                 >
-                  <CareerDetails data={CAREER_DUMMY_DATA} />
+                  <CareerDetails data={data.career} />
                 </BorderBox>
               </Box>
               <Box>
@@ -300,7 +189,24 @@ const ResumeDetailTemplate = () => {
                   p={7}
                   gap={10}
                 >
-                  <ProjectDetails data={PROJECT_DUMMY_DATA} />
+                  <ProjectDetails data={data.project} />
+                </BorderBox>
+              </Box>
+              <Box>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  활동
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  p={7}
+                  gap={10}
+                >
+                  <ActivityDetails data={data.activity} />
                 </BorderBox>
               </Box>
             </Flex>

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -9,6 +9,7 @@ import {
   CareerDetails,
   LanguageDetails,
   ProjectDetails,
+  TrainingDetails,
 } from '~/components/organisms/ResumeDetails';
 
 const ResumeDetailTemplate = () => {
@@ -240,7 +241,6 @@ const ResumeDetailTemplate = () => {
                   w={'100%'}
                   px={7}
                   py={10}
-                  gap={10}
                 >
                   <LanguageDetails data={data.language} />
                 </BorderBox>

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -3,8 +3,8 @@ type Activity = {
   startDate: string;
   endDate: string;
   inProgress: boolean;
-  link: string;
-  description: string;
+  link?: string;
+  description?: string;
 };
 
 export type { Activity };

--- a/src/types/award.ts
+++ b/src/types/award.ts
@@ -1,9 +1,9 @@
 type Award = {
   certificationTitle: string;
-  acquisitionDate: string;
-  issuingAuthority: string;
-  link: string;
-  description: string;
+  acquisitionDate?: string;
+  issuingAuthority?: string;
+  link?: string;
+  description?: string;
 };
 
 export type { Award };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/5e84311e-4f37-449f-b75a-4a10da35720b)
![image](https://github.com/resumeme/Frontend/assets/74141521/87e70301-bda6-4521-85cb-198e508c8894)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 목업 데이터를 파일로 분리했습니다. (`ResumeDetail.const.ts`)
- 아직 구현하지 않은 UI의 목업 데이터를 채워 넣었습니다.
- 이력서 상세 페이지의 활동 카테고리, 외국어 카테고리 UI를 구현하였습니다.
- `Award.ts`, `Activity.ts` 타입 파일의 선택 속성들을 적용했습니다.
- ProjectDetails 컴포넌트와 ActivityDetails 컴포넌트 내부의 차크라 `Link` 컴포넌트에 `href` 속성을 주어서 링크가 제대로 열리도록 동작하게 하였습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
