### PR TITLE
Gmmq 348 style: 이력서 상세 페이지 - 수상 및 자격 UI 구현

### DIFF
--- a/src/components/organisms/ResumeDetails/AwardDetails.tsx
+++ b/src/components/organisms/ResumeDetails/AwardDetails.tsx
@@ -1,6 +1,8 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, Text, Divider, Heading, Icon, Link } from '@chakra-ui/react';
+import React from 'react';
+import { HiLink } from 'react-icons/hi';
 import { v4 as uuidv4 } from 'uuid';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import { Award } from '~/types/award';
 
 const AwardDetails = ({ data }: { data: Award[] }) => {
@@ -9,22 +11,82 @@ const AwardDetails = ({ data }: { data: Award[] }) => {
   }
   return (
     <>
-      {data?.map((Award: Award) => {
-        return (
-          <BorderBox
-            key={uuidv4()}
-            w={'100%'}
-          >
-            <Flex direction={'column'}>
-              <Text as={'span'}>{Award.certificationTitle}</Text>
-              <Text as={'span'}>{Award.acquisitionDate}</Text>
-              <Text as={'span'}>{Award.description}</Text>
-              <Text as={'span'}>{Award.issuingAuthority}</Text>
-              <Text as={'span'}>{Award.link}</Text>
-            </Flex>
-          </BorderBox>
-        );
-      })}
+      {data?.map(
+        (
+          { certificationTitle, acquisitionDate, issuingAuthority, link, description }: Award,
+          index,
+        ) => {
+          return (
+            <React.Fragment key={uuidv4()}>
+              {index > 0 && (
+                <Divider
+                  key={index}
+                  my={'3rem'}
+                  borderColor={'gray.300'}
+                />
+              )}
+              <Flex>
+                <Flex flex={1}>
+                  {acquisitionDate && (
+                    <Label
+                      bg={'gray.300'}
+                      color={'gray.700'}
+                      h={'fit-content'}
+                      py={0}
+                      fontWeight={'medium'}
+                    >
+                      {acquisitionDate}
+                    </Label>
+                  )}
+                </Flex>
+                <Flex
+                  mt={'1%'}
+                  flex={2}
+                  direction={'column'}
+                >
+                  <Flex
+                    direction={'column'}
+                    width={'full'}
+                    gap={2}
+                  >
+                    <Flex
+                      gap={4}
+                      align={'flex-end'}
+                    >
+                      <Heading
+                        fontSize={'xl'}
+                        fontWeight={'bold'}
+                        color={'gray.800'}
+                      >
+                        {certificationTitle}
+                      </Heading>
+                      {issuingAuthority && <Text>{issuingAuthority}</Text>}
+                    </Flex>
+                    {description && <Text mt={5}>{description}</Text>}
+                    {link && (
+                      <Flex
+                        mt={5}
+                        gap={3}
+                        align={'center'}
+                      >
+                        <Icon as={HiLink} />
+                        <Link
+                          isExternal
+                          href={link}
+                          fontSize={'sm'}
+                          color={'primary.900'}
+                        >
+                          {link}
+                        </Link>
+                      </Flex>
+                    )}
+                  </Flex>
+                </Flex>
+              </Flex>
+            </React.Fragment>
+          );
+        },
+      )}
     </>
   );
 };

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -54,7 +54,7 @@ const EditResumeTemplate = () => {
           <ProjectForm />
         </ResumeCategory>
         <ResumeCategory
-          categoryType="수상 및 경력"
+          categoryType="수상 및 자격"
           detailsComponent={<AwardDetails data={awardData} />}
         >
           <AwardForm />

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -6,6 +6,7 @@ import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
 import {
   ActivityDetails,
+  AwardDetails,
   CareerDetails,
   LanguageDetails,
   ProjectDetails,
@@ -209,6 +210,23 @@ const ResumeDetailTemplate = () => {
                   gap={10}
                 >
                   <TrainingDetails data={data.training} />
+                </BorderBox>
+              </Box>
+              <Box>
+                <Text
+                  fontSize={'2xl'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                  mb={5}
+                >
+                  수상 및 자격증
+                </Text>
+                <BorderBox
+                  w={'100%'}
+                  p={7}
+                  gap={10}
+                >
+                  <AwardDetails data={data.award} />
                 </BorderBox>
               </Box>
               <Box>

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -219,7 +219,7 @@ const ResumeDetailTemplate = () => {
                   color={'gray.800'}
                   mb={5}
                 >
-                  수상 및 자격증
+                  수상 및 자격
                 </Text>
                 <BorderBox
                   w={'100%'}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/bf982d4a-ac7b-4aef-a9ee-64035f92d58a)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 상세 페이지의 '수상 및 자격' 카테고리 UI를 구현했습니다.
- `수상 및 경력` / `수상 및 자격증` -> **`수상 및 자격`** 으로 통일하고 수정했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
