### PR TITLE
Gmmq 384 feat: 유저 정보 저장하기

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,12 +1,24 @@
 import axios from 'axios';
 import { redirect } from 'react-router-dom';
 import { environments } from '~/config/environments';
+import CONSTANTS from '~/constants';
+import { getCookie, setCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
   baseURL: environments.baseUrlEnv(),
   headers: {
     'Content-Type': 'application/json',
   },
+});
+
+resumeMeAxios.interceptors.request.use((config) => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+  if (accessToken) {
+    config.headers[CONSTANTS.ACCESS_TOKEN_HEADER] = `Bearer ${accessToken}`;
+  }
+
+  return config;
 });
 
 resumeMeAxios.interceptors.response.use(

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { redirect } from 'react-router-dom';
 import { environments } from '~/config/environments';
 import CONSTANTS from '~/constants';
-import { getCookie } from '~/utils/cookie';
+import { getCookie, setCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
   baseURL: environments.baseUrlEnv(),
@@ -15,7 +15,7 @@ resumeMeAxios.interceptors.request.use((config) => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
 
   if (accessToken) {
-    config.headers[CONSTANTS.ACCESS_TOKEN_HEADER] = `Bearer ${accessToken}`;
+    config.headers[CONSTANTS.ACCESS_TOKEN_HEADER] = accessToken;
   }
 
   return config;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { redirect } from 'react-router-dom';
 import { environments } from '~/config/environments';
 import CONSTANTS from '~/constants';
-import { getCookie, setCookie } from '~/utils/cookie';
+import { getCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
   baseURL: environments.baseUrlEnv(),

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -30,8 +30,9 @@ const useUser = () => {
     gcTime: Infinity,
   });
 
-  const initialUser = async (accessToken: string) => {
+  const initialUser = async (accessToken: string, refreshToken: string) => {
     setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, accessToken);
+    setCookie(CONSTANTS.REFRESH_TOKEN_HEADER, refreshToken, 100);
     refetch();
   };
 

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,4 +1,4 @@
-import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { resumeMeAxios } from '~/api/axios';
 import CONSTANTS from '~/constants';
 import { User } from '~/types/user';

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,48 @@
+import { useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { User } from '~/types/user';
+import { getCookie, deleteCookie, setCookie } from '~/utils/cookie';
+
+export const userKeys = {
+  user: ['user'] as const,
+};
+
+const getUser = async (): Promise<User | null> => {
+  if (!getCookie(CONSTANTS.ACCESS_TOKEN_HEADER)) return null;
+
+  const { data } = await resumeMeAxios.get('/v1/user');
+
+  if (!data) {
+    deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+    return null;
+  }
+
+  return data;
+};
+
+const useUser = () => {
+  const queryClient = useQueryClient();
+
+  const { data: user, refetch } = useSuspenseQuery({
+    queryKey: userKeys.user,
+    queryFn: getUser,
+    staleTime: Infinity,
+    gcTime: Infinity,
+  });
+
+  const initialUser = async (accessToken: string) => {
+    setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, accessToken);
+    refetch();
+  };
+
+  const clearUser = () => {
+    queryClient.setQueryData(userKeys.user, null);
+    deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+  };
+
+  return { user, clearUser, initialUser };
+};
+
+export default useUser;

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -23,8 +23,6 @@ const getUser = async (): Promise<User | null> => {
 };
 
 const useUser = () => {
-  const queryClient = useQueryClient();
-
   const { data: user, refetch } = useSuspenseQuery({
     queryKey: userKeys.user,
     queryFn: getUser,
@@ -38,8 +36,8 @@ const useUser = () => {
   };
 
   const clearUser = () => {
-    queryClient.setQueryData(userKeys.user, null);
     deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+    refetch();
   };
 
   return { user, clearUser, initialUser };

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -1,11 +1,16 @@
+import { Text } from '@chakra-ui/react';
 import { Button } from '~/components/atoms/Button';
+import useUser from '~/hooks/useUser';
 import { usePostCreateResume } from '~/queries/resume/create/usePostCreateResume';
 
 const MainPage = () => {
   const resumeCreateMutation = usePostCreateResume();
+  const { user } = useUser();
+
   const handleResumeCreate = () => {
     resumeCreateMutation.mutate();
   };
+
   return (
     <>
       {/**FIXME - 아래는 임시 이력서 작성 버튼, 추후 대체할 것 */}
@@ -15,6 +20,10 @@ const MainPage = () => {
       >
         새 이력서 작성
       </Button>
+      <Text>{user?.careerContent}</Text>
+      <Text>{user?.careerYear}</Text>
+      <Text>{user?.realName}</Text>
+      <Text>{user?.nickname}</Text>
     </>
   );
 };

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { appPaths } from '~/config/paths';
 import CONSTANTS from '~/constants';
+import useUser from '~/hooks/useUser';
 import { usePostOAuthSignIn } from '~/queries/usePostOAuthSignIn';
 import { useCacheKeyStore } from '~/stores/useCacheKeyStore';
 import { setCookie } from '~/utils/cookie';
@@ -13,9 +14,12 @@ const OAuthRedirectPage = () => {
   const code = params.get('code');
   const navigate = useNavigate();
   const toast = useToast();
+  const { initialUser } = useUser();
 
   type SignInCallback = { cacheKey?: string; accessToken?: string; refreshToken?: string };
+
   const setCacheKey = useCacheKeyStore((state) => state.setCacheKey);
+
   const signInCallback = ({ cacheKey, accessToken, refreshToken }: SignInCallback) => {
     // 새로운 사용자가 로그인한 경우
     if (cacheKey) {
@@ -27,7 +31,7 @@ const OAuthRedirectPage = () => {
     /**TODO - Authorization, refresh 토큰 저장 */
 
     if (accessToken && refreshToken) {
-      setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, accessToken, 30);
+      initialUser(accessToken);
       setCookie(CONSTANTS.REFRESH_TOKEN_HEADER, refreshToken, 100);
     }
     toast({

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -26,8 +26,6 @@ const OAuthRedirectPage = () => {
       return;
     }
     // 기존 사용자가 로그인한 경우
-    /**TODO - Authorization, refresh 토큰 저장 */
-
     if (accessToken && refreshToken) {
       initialUser(accessToken, refreshToken);
     }

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -3,11 +3,9 @@ import { useToast } from '@chakra-ui/react';
 import { useEffect } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { appPaths } from '~/config/paths';
-import CONSTANTS from '~/constants';
 import useUser from '~/hooks/useUser';
 import { usePostOAuthSignIn } from '~/queries/usePostOAuthSignIn';
 import { useCacheKeyStore } from '~/stores/useCacheKeyStore';
-import { setCookie } from '~/utils/cookie';
 
 const OAuthRedirectPage = () => {
   const [params] = useSearchParams();
@@ -31,8 +29,7 @@ const OAuthRedirectPage = () => {
     /**TODO - Authorization, refresh 토큰 저장 */
 
     if (accessToken && refreshToken) {
-      initialUser(accessToken);
-      setCookie(CONSTANTS.REFRESH_TOKEN_HEADER, refreshToken, 100);
+      initialUser(accessToken, refreshToken);
     }
     toast({
       title: '로그인 성공',

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -4,6 +4,7 @@ import { SignUpCompleteTemplate } from '~/components/templates/SignUpCompleteTem
 import { SignUpMenteeTemplate } from '~/components/templates/SignUpMenteeTemplate';
 import { SignUpMentorTemplate } from '~/components/templates/SignUpMentorTemplate';
 import CONSTANTS from '~/constants';
+import useUser from '~/hooks/useUser';
 import { usePostOAuthSignUp } from '~/queries/usePostOAuthSignUp';
 import { useCacheKeyStore } from '~/stores/useCacheKeyStore';
 import { SignUpRole, SignUpCommon } from '~/types/signUp';
@@ -17,12 +18,13 @@ const SignUpPage = () => {
   const { mutate: signUpMutate } = usePostOAuthSignUp();
   const cacheKey = useCacheKeyStore((state) => state.cacheKey);
   const resetCacheKey = useCacheKeyStore((state) => state.resetCacheKey);
+  const { initialUser } = useUser();
 
   const signUpSuccessCallback = (accessToken: string, refreshToken: string, role: SignUpRole) => {
     const nextStep = role === 'ROLE_MENTEE' ? 'MENTEE_COMPLETE' : 'MENTOR_COMPLETE';
     resetCacheKey();
     setStep(nextStep);
-    setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, accessToken, 30);
+    initialUser(accessToken);
     setCookie(CONSTANTS.REFRESH_TOKEN_HEADER, refreshToken, 100);
   };
 

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -24,8 +24,9 @@ const SignUpPage = () => {
     const nextStep = role === 'ROLE_MENTEE' ? 'MENTEE_COMPLETE' : 'MENTOR_COMPLETE';
     resetCacheKey();
     setStep(nextStep);
-    initialUser(accessToken);
-    setCookie(CONSTANTS.REFRESH_TOKEN_HEADER, refreshToken, 100);
+    if (accessToken && refreshToken) {
+      initialUser(accessToken, refreshToken);
+    }
   };
 
   return (

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -3,12 +3,10 @@ import { SignUpCommonTemplate } from '~/components/templates/SignUpCommonTemplat
 import { SignUpCompleteTemplate } from '~/components/templates/SignUpCompleteTemplate';
 import { SignUpMenteeTemplate } from '~/components/templates/SignUpMenteeTemplate';
 import { SignUpMentorTemplate } from '~/components/templates/SignUpMentorTemplate';
-import CONSTANTS from '~/constants';
 import useUser from '~/hooks/useUser';
 import { usePostOAuthSignUp } from '~/queries/usePostOAuthSignUp';
 import { useCacheKeyStore } from '~/stores/useCacheKeyStore';
 import { SignUpRole, SignUpCommon } from '~/types/signUp';
-import { setCookie } from '~/utils/cookie';
 
 export type Step = 'COMMON' | SignUpRole | 'MENTOR_COMPLETE' | 'MENTEE_COMPLETE';
 


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
react-query를 이용해서 유저 정보를 유지했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
아래 5개 파일만 확인하시면 됩니다!
src\api\axios.ts
src\hooks\useUser.ts
src\pages\MainPage\MainPage.tsx
src\pages\SignInPage\OAuthRedirectPage.tsx
src\pages\SignUpPage\SignUpPage.tsx


맨 처음 useQuery를 통해서 user에 대한 정보를 가져옵니다.
```tsx
const getUser = async (): Promise<User | null> => {
  //쿠키에 저장되어있는 토큰 값이 없다면 null을 반환합니다.
  if (!getCookie(CONSTANTS.ACCESS_TOKEN_HEADER)) return null;

  //토큰 값이 있다면 유저에 대한 정보를 요청합니다.
  //토큰 값은 axios의 인터셉터를 통해서 요청을 보낼 때 마다 헤더에 포함됩니다.
  const { data } = await resumeMeAxios.get('/v1/user');

  //데이터가 없다면 토큰 값이 잘못된것으로 판단하고 저장된 쿠키 값을 삭제합니다.
  //리프레시 토큰을 활용한내용은 axios에 추후 PR에 올리겠습니다.
  if (!data) {
    deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);

    return null;
  }

  return data;
};
```

유저가 로그인, 회원가입을 진행하고 토큰을 받으면 user에 대한 정보를 업데이트 합니다.
```tsx
const initialUser = async (accessToken: string) => {
  //쿠키에 토큰 값을 먼저 저장 시키고 다시 getUser를 실행합니다.
  setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, accessToken);
  //useQuery를 적극적으로 활용하기 위해서 refetch()를 사용했는데,
  //const { data } = await resumeMeAxios.get('/v1/user'); 해당 내용을 실행 후에
  //queryClient.setQueryData(userKeys.user, data); 이런 식으로 하는 방법도 있었습니다.
  //추후에 user값이 문제가 된다면 수정해야할 것 같아서 적어놓습니다.
  refetch();
};
```
유저가 로그아웃을 진행했을 때, user에 대한 정보를 업데이트 합니다.
```tsx
const clearUser = () => {
  deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
  refetch();
};
```

user에 대한 정보가 필요한 곳에서 user를 꺼내서 사용하면 되지 않을까 싶습니다!

## 🔎 PR포인트 및 궁금한 점
