### PR TITLE
Gmmp 471 style: 교육 폼 왼쪽 정렬

### DIFF
--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -1,4 +1,4 @@
-import { Flex, VStack } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { BorderBox } from '~/components/atoms/BorderBox';
@@ -62,7 +62,10 @@ const TrainingForm = () => {
       {showForm && (
         <BorderBox variant={'wide'}>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <VStack spacing={'1.25rem'}>
+            <Flex
+              gap={'1.25rem'}
+              direction={'column'}
+            >
               <Flex gap={'2rem'}>
                 <FormControl isInvalid={Boolean(errors.organization)}>
                   <FormLabel
@@ -219,7 +222,7 @@ const TrainingForm = () => {
                 proceed={handleDeleteForm}
               />
               <SubmitButtonGroup onCancel={handleCancel} />
-            </VStack>
+            </Flex>
           </form>
         </BorderBox>
       )}

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -1,4 +1,4 @@
-import { Flex } from '@chakra-ui/react';
+import { Flex, VStack } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useNavigate, useParams } from 'react-router-dom';
 import { BorderBox } from '~/components/atoms/BorderBox';
@@ -36,7 +36,7 @@ const TrainingForm = () => {
   });
 
   const { id: resumeId } = useParams();
-  const { mutate } = usePostResumeTraining();
+  const { mutate: postTrainingMutate } = usePostResumeTraining();
   const navigate = useNavigate();
   const onSubmit: SubmitHandler<Training> = (resumeTraining: Training) => {
     if (!resumeId) {
@@ -45,7 +45,8 @@ const TrainingForm = () => {
       navigate(-1);
       return;
     }
-    mutate({ resumeId, resumeTraining });
+    postTrainingMutate({ resumeId, resumeTraining });
+    handleDeleteForm();
   };
 
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
@@ -62,11 +63,11 @@ const TrainingForm = () => {
       {showForm && (
         <BorderBox variant={'wide'}>
           <form onSubmit={handleSubmit(onSubmit)}>
-            <Flex
-              gap={'1.25rem'}
-              direction={'column'}
-            >
-              <Flex gap={'2rem'}>
+            <VStack spacing={'1.25rem'}>
+              <Flex
+                gap={'2rem'}
+                alignSelf={'start'}
+              >
                 <FormControl isInvalid={Boolean(errors.organization)}>
                   <FormLabel
                     htmlFor="organization"
@@ -120,7 +121,10 @@ const TrainingForm = () => {
                   />
                 </FormControl>
               </Flex>
-              <Flex gap={'2rem'}>
+              <Flex
+                gap={'2rem'}
+                alignSelf={'start'}
+              >
                 <FormControl
                   w={'fit-content'}
                   isInvalid={Boolean(errors.admissionDate)}
@@ -161,7 +165,10 @@ const TrainingForm = () => {
                   />
                 </FormControl>
               </Flex>
-              <Flex gap={'3rem'}>
+              <Flex
+                gap={'3rem'}
+                alignSelf={'start'}
+              >
                 <FormControl
                   w={'fit-content'}
                   isInvalid={Boolean(errors.gpa)}
@@ -222,7 +229,7 @@ const TrainingForm = () => {
                 proceed={handleDeleteForm}
               />
               <SubmitButtonGroup onCancel={handleCancel} />
-            </Flex>
+            </VStack>
           </form>
         </BorderBox>
       )}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="898" alt="스크린샷 2023-11-14 오전 1 58 18" src="https://github.com/resumeme/Frontend/assets/91667853/9738e244-f2f7-4397-a62a-68c414614b00">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 기존에 폼 input들이 가운데 정렬되던 것을 왼쪽 정렬되도록 수정했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
