### PR TITLE
Gmmq 470 fix: 이력서 교육 카테고리 get 안되는 문제 수정

### DIFF
--- a/src/queries/resume/create/usePostResumeTraining.ts
+++ b/src/queries/resume/create/usePostResumeTraining.ts
@@ -1,9 +1,27 @@
 import { useMutation } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { postResumeTraining } from '~/api/resume/create/postResumeTraining';
+import { Activity } from '~/types/activity';
 
 export const usePostResumeTraining = () => {
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = 'getResumeTraining';
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeTraining,
+    onMutate: async (newProject) => {
+      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
+      const previousProjects = queryClient.getQueryData([TARGET_QUERY_KEY]);
+      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Activity[]) => [...old, newProject]);
+      return { previousProjects };
+    },
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    onError: (err, newProject, context) => {
+      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousProjects);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+    },
   });
 };

--- a/src/queries/resume/details/useGetResumeTraining.ts
+++ b/src/queries/resume/details/useGetResumeTraining.ts
@@ -3,7 +3,7 @@ import { GetResumeTraining, getResumeTraining } from '~/api/resume/details/getRe
 
 export const useGetResumeTraining = ({ resumeId }: GetResumeTraining) => {
   return useQuery({
-    queryKey: ['getResumeCareer'],
+    queryKey: ['getResumeTraining'],
     queryFn: () => getResumeTraining({ resumeId }),
     enabled: !!resumeId,
   });


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 교육만 get요청이 가지 않는 문제가 있었습니다.
- 원인은.. queryKey를 업무경험 queryKey로 복붙해놓은 걸 수정을 안했더라구요 😂
- 추가로 교육 mutation만 onMutate 낙관적 업데이트 적용이 안되어있어 작성해뒀습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 서버가 닫혀서 테스트는 못했는데, 서버 다시 오픈되면 테스트 후에 머지하도록 하겠습니다.
- 현재는 queryKey를 하드코딩으로 박아놓은 상태인데, queries 내에 constants폴더 따로 만들어서 나중에 한꺼번에 상수 처리하는 것도 좋을 것 같습니다.

## 🔎 PR포인트 및 궁금한 점
