### PR TITLE
Gmmq 391 feat: 유효하지 않은 토큰 처리

### DIFF
--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { redirect } from 'react-router-dom';
 import { environments } from '~/config/environments';
 import CONSTANTS from '~/constants';
-import { getCookie, setCookie } from '~/utils/cookie';
+import { getCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
   baseURL: environments.baseUrlEnv(),

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { redirect } from 'react-router-dom';
 import { environments } from '~/config/environments';
 import CONSTANTS from '~/constants';
-import { getCookie } from '~/utils/cookie';
+import { getCookie, setCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
   baseURL: environments.baseUrlEnv(),

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -13,12 +13,6 @@ const getUser = async (): Promise<User | null> => {
 
   const { data } = await resumeMeAxios.get('/v1/user');
 
-  if (!data) {
-    deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
-
-    return null;
-  }
-
   return data;
 };
 


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
토큰기간이 만료됐을 때를 처리했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
```tsx
if (code === 'INVALID_ACCESS_TOKEN') { //유효하지 않은 토큰일 때
  const originalRequest = error.config; //실패한 요청의 정보를 받아옵니다. (header,data 등등)

  const refreshToken = getCookie(CONSTANTS.REFRESH_TOKEN_HEADER); //리프레시 토큰을 받아옵니다.

  originalRequest._retry = true; //다시 요청을 보낼 수 있도록 설정합니다.
  originalRequest.headers[CONSTANTS.REFRESH_TOKEN_HEADER] = refreshToken; //헤더에 리프레시 토큰을 추가합니다.

  const { headers } = await resumeMeAxios(originalRequest); //실패했던 요청과 동일한 요청을 보내면, headers에 새로운 엑세스 토큰이 실려옵니다.

  const newAccessToken = headers[CONSTANTS.ACCESS_TOKEN_HEADER]; //새로운 엑세스 토큰을 받아와서 저장합니다.

  setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, newAccessToken);
}
```

axios에서 해당과정을 처리해서 다시 보낸요청이 성공했을때 추가적인 작업을 할 수 없어서 추후에 queryClient를 사용하여 고쳐야 할 것 같습니다.
ex) onSuccess에 있는 navigate와 같은 동작들

## 🔎 PR포인트 및 궁금한 점
