### PR TITLE
Gmmq 400 feat: 이력서 첨삭 페이지 - 첨삭 코멘트 뷰어 UI

### DIFF
--- a/src/components/molecules/FeedbackInput/index.ts
+++ b/src/components/molecules/FeedbackInput/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackInput } from './FeedbackInput';

--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -1,12 +1,15 @@
 import { Box, Flex, Text, Divider, Icon, Tooltip } from '@chakra-ui/react';
 import MDEditor from '@uiw/react-md-editor';
 import { HiPencilAlt, HiTrash } from 'react-icons/hi';
-import { BorderBox } from '../../atoms/BorderBox';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { formatKoreanDateWithoutSeconds } from '~/utils/formatDate';
 import '@uiw/react-markdown-preview/markdown.css';
 
 type FeedbackViewProps = {
   content?: string;
-  lastEditDate?: string;
+  lastModifiedAt?: string;
+  commentId?: number;
+  componentId?: number;
 };
 
 const LABELS = {
@@ -18,8 +21,25 @@ const LABELS = {
 const FeedbackView = ({
   content = `## 테스트
 - **반갑습니다.**`,
-  lastEditDate = '2023-11-15 수요일',
+  lastModifiedAt = '2023-11-15 17:17:09',
+  commentId,
+  componentId,
 }: FeedbackViewProps) => {
+  const handleRemove = () => {
+    /* TODO 코멘트 삭제 API */
+    alert(`commentId: ${commentId}`);
+  };
+
+  const handleEdit = () => {
+    /* TODO 코멘트 수정 함수
+      - componentId, commentId로 FeedbackInput 컴포넌트 보여줌
+      - FeedbackView 컴포넌트 숨김
+    */
+    alert(`componentId: ${componentId}`);
+  };
+
+  const fomattedDate = formatKoreanDateWithoutSeconds(lastModifiedAt);
+
   return (
     <BorderBox p={0}>
       <Flex
@@ -36,7 +56,7 @@ const FeedbackView = ({
             fontSize={'sm'}
             fontWeight={'semibold'}
           >
-            {lastEditDate}에 작성된 피드백
+            {fomattedDate}에 작성된 피드백
           </Text>
         </Flex>
         <Flex
@@ -45,7 +65,7 @@ const FeedbackView = ({
         >
           <Box
             as="button"
-            onClick={() => alert('수정버튼 눌림')}
+            onClick={handleEdit}
           >
             <Tooltip
               label={LABELS.EDIT}
@@ -62,7 +82,7 @@ const FeedbackView = ({
           </Box>
           <Box
             as="button"
-            onClick={() => alert('삭제버튼 눌림')}
+            onClick={handleRemove}
           >
             <Tooltip
               label={LABELS.REMOVE}
@@ -101,7 +121,7 @@ const FeedbackView = ({
             fontWeight={'light'}
             color={'gray.500'}
           >
-            {lastEditDate}
+            {lastModifiedAt}
           </Text>
         </Flex>
       </Flex>

--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -1,0 +1,112 @@
+import { Box, Flex, Text, Divider, Icon, Tooltip } from '@chakra-ui/react';
+import MDEditor from '@uiw/react-md-editor';
+import { HiPencilAlt, HiTrash } from 'react-icons/hi';
+import { BorderBox } from '../../atoms/BorderBox';
+import '@uiw/react-markdown-preview/markdown.css';
+
+type FeedbackViewProps = {
+  content?: string;
+  lastEditDate?: string;
+};
+
+const LABELS = {
+  EDIT: '수정하기',
+  REMOVE: '삭제하기',
+  HEADER: '첨삭',
+};
+
+const FeedbackView = ({
+  content = `## 테스트
+- **반갑습니다.**`,
+  lastEditDate = '2023-11-15 수요일',
+}: FeedbackViewProps) => {
+  return (
+    <BorderBox p={0}>
+      <Flex
+        justify={'space-between'}
+        borderWidth="1px"
+        borderTopRadius="1.06rem"
+        borderColor={'transparent'}
+        bg={'gray.200'}
+        px={5}
+        py={2}
+      >
+        <Flex align={'flex-end'}>
+          <Text
+            fontSize={'sm'}
+            fontWeight={'semibold'}
+          >
+            {lastEditDate}에 작성된 피드백
+          </Text>
+        </Flex>
+        <Flex
+          gap={3}
+          align={'end'}
+        >
+          <Box
+            as="button"
+            onClick={() => alert('수정버튼 눌림')}
+          >
+            <Tooltip
+              label={LABELS.EDIT}
+              placement="top"
+              hasArrow
+            >
+              <span>
+                <Icon
+                  as={HiPencilAlt}
+                  alignSelf={'flex-end'}
+                />
+              </span>
+            </Tooltip>
+          </Box>
+          <Box
+            as="button"
+            onClick={() => alert('삭제버튼 눌림')}
+          >
+            <Tooltip
+              label={LABELS.REMOVE}
+              placement="top"
+              hasArrow
+            >
+              <span>
+                <Icon as={HiTrash} />
+              </span>
+            </Tooltip>
+          </Box>
+        </Flex>
+      </Flex>
+
+      <Divider />
+
+      <Flex
+        px={5}
+        py={3}
+        direction={'column'}
+      >
+        <Box
+          height={'full'}
+          width={'full'}
+          data-color-mode="light"
+          px={1}
+        >
+          <MDEditor.Markdown
+            source={content}
+            style={{ whiteSpace: 'pre-wrap' }}
+          />
+        </Box>
+        <Flex justify={'flex-end'}>
+          <Text
+            fontSize={'xs'}
+            fontWeight={'light'}
+            color={'gray.500'}
+          >
+            {lastEditDate}
+          </Text>
+        </Flex>
+      </Flex>
+    </BorderBox>
+  );
+};
+
+export default FeedbackView;

--- a/src/components/molecules/FeedbackView/index.stories.tsx
+++ b/src/components/molecules/FeedbackView/index.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta } from '@storybook/react';
+import FeedbackView from './FeedbackView';
+
+const meta = {
+  title: 'Resumeme/Components/FeedbackView',
+  component: FeedbackView,
+  tags: ['autodocs'],
+} satisfies Meta<typeof FeedbackView>;
+
+export default meta;
+
+export const Default = () => {
+  return (
+    <div>
+      <FeedbackView />
+    </div>
+  );
+};

--- a/src/components/molecules/FeedbackView/index.ts
+++ b/src/components/molecules/FeedbackView/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackView } from './FeedbackView';

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,4 +2,32 @@ const formatDate = (date: string) => {
   return date.slice(0, 10).replace(/-/g, '. ');
 };
 
-export { formatDate };
+const formatKoreanDateWithMinutes = (date: string) => {
+  const [datePart, timePart] = date.split(' ');
+  const [year, month, day] = datePart.split('-');
+  const [hour, minute] = timePart.split(':');
+
+  const formattedDate = `${year}년 ${month}월 ${day}일`;
+  const period = +hour >= 12 ? '오후' : '오전';
+  const formattedHour = +hour % 12 === 0 ? 12 : +hour % 12;
+
+  const formattedTime = `${period} ${formattedHour}시 ${minute}분`;
+
+  return `${formattedDate} ${formattedTime}`;
+};
+
+const formatKoreanDate = (date: string) => {
+  const [datePart, timePart] = date.split(' ');
+  const [year, month, day] = datePart.split('-');
+  const [hour, minute, second] = timePart.split(':');
+
+  const formattedDate = `${year}년 ${month}월 ${day}일`;
+  const period = +hour >= 12 ? '오후' : '오전';
+  const formattedHour = +hour % 12 === 0 ? 12 : +hour % 12;
+
+  const formattedTime = `${period} ${formattedHour}시 ${minute}분 ${second}초`;
+
+  return `${formattedDate} ${formattedTime}`;
+};
+
+export { formatDate, formatKoreanDate, formatKoreanDateWithMinutes };

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -2,7 +2,7 @@ const formatDate = (date: string) => {
   return date.slice(0, 10).replace(/-/g, '. ');
 };
 
-const formatKoreanDateWithMinutes = (date: string) => {
+const formatKoreanDateWithoutSeconds = (date: string) => {
   const [datePart, timePart] = date.split(' ');
   const [year, month, day] = datePart.split('-');
   const [hour, minute] = timePart.split(':');
@@ -30,4 +30,4 @@ const formatKoreanDate = (date: string) => {
   return `${formattedDate} ${formattedTime}`;
 };
 
-export { formatDate, formatKoreanDate, formatKoreanDateWithMinutes };
+export { formatDate, formatKoreanDate, formatKoreanDateWithoutSeconds };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<div align="center">

![image](https://github.com/resumeme/Frontend/assets/74141521/2121019c-ba89-4d7f-909b-b63e3010ca65)
**[디자인 시안 - 윗 부분]**

<br /><br />

![Screenshot 2023-11-15 at 17 32 28-commentviewer](https://github.com/resumeme/Frontend/assets/74141521/ce49bfe7-e9d5-4ff9-8386-e831c2f191f7)
**[완성 UI]**

</div>

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 멘토가 이력서를 첨삭할 때 사용하는 첨삭 코멘트의 뷰어 UI입니다.
- 들어올 데이터로 `content(마크다운)`, `lastEditDate(최종 수정 날짜)`가 필요합니다.
- FeedbackInput (첨삭 코멘트 작성 컴포넌트)와 FeedbackView (첨삭 코멘트 뷰어 컴포넌트)에 index.ts 내보내기를 추가했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
