### PR TITLE
Gmmq 500 refactor: 이력서 카테고리 useQuery 키 상수 처리

### DIFF
--- a/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
+++ b/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
@@ -37,8 +37,8 @@ const ActivityForm = () => {
     // },
   });
 
-  const { id: resumeId } = useParams();
-  const { mutate: postActivityMutate, isSuccess } = usePostResumeActivity();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postActivityMutate, isSuccess } = usePostResumeActivity(resumeId);
   const toast = useToast();
   const onSubmit: SubmitHandler<Activity> = (resumeActivity: Activity) => {
     if (!resumeId) {

--- a/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
+++ b/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
@@ -16,8 +16,8 @@ import { usePostResumeAward } from '~/queries/resume/create/usePostResumeAward';
 import { Award } from '~/types/award';
 
 const AwardForm = () => {
-  const { id: resumeId } = useParams();
-  const { mutate: postResumeAward, isSuccess } = usePostResumeAward();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postResumeAward, isSuccess } = usePostResumeAward(resumeId);
   const toast = useToast();
 
   const {

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -48,8 +48,8 @@ const CareerForm = () => {
     name: 'duties',
   });
 
-  const { id: resumeId } = useParams();
-  const { mutate: postCareerMutate, isSuccess } = usePostResumeCareer();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postCareerMutate, isSuccess } = usePostResumeCareer(resumeId);
   const toast = useToast();
   const [skills, handleArrayChange, handleItemDelete] = useStringToArray();
   const onSubmit = handleSubmit((resumeCareer) => {

--- a/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
+++ b/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
@@ -20,8 +20,8 @@ const LanguageForm = () => {
     reset,
   } = useForm<Language>();
 
-  const { id: resumeId } = useParams();
-  const { mutate: postLanguageMutate, isSuccess } = usePostResumeLanguage();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postLanguageMutate, isSuccess } = usePostResumeLanguage(resumeId);
   const toast = useToast();
   const onSubmit = (resumeLanguage: Language) => {
     if (!resumeId) {

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -19,8 +19,8 @@ import { Project } from '~/types/project';
 const ProjectForm = () => {
   const [skills, handleSkills, handleDeleteSkills] = useStringToArray();
 
-  const { id: resumeId } = useParams();
-  const { mutate: postResumeProject, isSuccess } = usePostResumeProject();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postResumeProject, isSuccess } = usePostResumeProject(resumeId);
   const toast = useToast();
 
   const {

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -35,8 +35,8 @@ const TrainingForm = () => {
     // },
   });
 
-  const { id: resumeId } = useParams();
-  const { mutate: postTrainingMutate, isSuccess } = usePostResumeTraining();
+  const { id: resumeId } = useParams() as { id: string };
+  const { mutate: postTrainingMutate, isSuccess } = usePostResumeTraining(resumeId);
   const toast = useToast();
   const onSubmit: SubmitHandler<Training> = (resumeTraining: Training) => {
     if (!resumeId) {

--- a/src/queries/resume/categoryKeys.const.ts
+++ b/src/queries/resume/categoryKeys.const.ts
@@ -1,0 +1,8 @@
+export const categoryKeys = {
+  activities: ['getActivities'] as const,
+  award: ['getAward'] as const,
+  career: ['getCareer'] as const,
+  language: ['getLanguage'] as const,
+  project: ['getProject'] as const,
+  training: ['getTraining'] as const,
+};

--- a/src/queries/resume/categoryKeys.const.ts
+++ b/src/queries/resume/categoryKeys.const.ts
@@ -1,8 +1,9 @@
 export const categoryKeys = {
-  activities: ['getActivities'] as const,
-  award: ['getAward'] as const,
-  career: ['getCareer'] as const,
-  language: ['getLanguage'] as const,
-  project: ['getProject'] as const,
-  training: ['getTraining'] as const,
+  all: ['category'] as const,
+  activities: (resumeId: string) => [...categoryKeys.all, 'getActivities', resumeId] as const,
+  award: (resumeId: string) => [...categoryKeys.all, 'getAward', resumeId] as const,
+  career: (resumeId: string) => [...categoryKeys.all, 'getCareer', resumeId] as const,
+  language: (resumeId: string) => [...categoryKeys.all, 'getLanguage', resumeId] as const,
+  project: (resumeId: string) => [...categoryKeys.all, 'getProject', resumeId] as const,
+  training: (resumeId: string) => [...categoryKeys.all, 'getTraining', resumeId] as const,
 };

--- a/src/queries/resume/categoryKeys.const.ts
+++ b/src/queries/resume/categoryKeys.const.ts
@@ -1,6 +1,6 @@
 export const categoryKeys = {
   all: ['category'] as const,
-  activities: (resumeId: string) => [...categoryKeys.all, 'getActivities', resumeId] as const,
+  activity: (resumeId: string) => [...categoryKeys.all, 'getActivities', resumeId] as const,
   award: (resumeId: string) => [...categoryKeys.all, 'getAward', resumeId] as const,
   career: (resumeId: string) => [...categoryKeys.all, 'getCareer', resumeId] as const,
   language: (resumeId: string) => [...categoryKeys.all, 'getLanguage', resumeId] as const,

--- a/src/queries/resume/create/usePostResumeActivity.ts
+++ b/src/queries/resume/create/usePostResumeActivity.ts
@@ -6,7 +6,7 @@ import { Activity } from '~/types/activity';
 
 export const usePostResumeActivity = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.activities(resumeId);
+  const TARGET_QUERY_KEY = categoryKeys.activity(resumeId);
   return useMutation({
     mutationKey: ['postActivity'],
     mutationFn: postResumeActivity,

--- a/src/queries/resume/create/usePostResumeActivity.ts
+++ b/src/queries/resume/create/usePostResumeActivity.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeActivity } from '~/api/resume/create/postResumeActivity';
 import { Activity } from '~/types/activity';
 
-export const usePostResumeActivity = () => {
+export const usePostResumeActivity = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.activities;
+  const TARGET_QUERY_KEY = categoryKeys.activities(resumeId);
   return useMutation({
     mutationKey: ['postActivity'],
     mutationFn: postResumeActivity,

--- a/src/queries/resume/create/usePostResumeActivity.ts
+++ b/src/queries/resume/create/usePostResumeActivity.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeActivity } from '~/api/resume/create/postResumeActivity';
 import { Activity } from '~/types/activity';
 
 export const usePostResumeActivity = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeActivity';
+  const TARGET_QUERY_KEY = categoryKeys.activities;
   return useMutation({
     mutationKey: ['postActivity'],
     mutationFn: postResumeActivity,
     onMutate: async (newActivity) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousActivities = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Activity[]) => [...old, newActivity]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousActivities = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Activity[]) => [...old, newActivity]);
       return { previousActivities };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newActivity, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousActivities);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousActivities);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/create/usePostResumeAward.ts
+++ b/src/queries/resume/create/usePostResumeAward.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeAward } from '~/api/resume/create/postResumeAward';
 import { Award } from '~/types/award';
 
 export const usePostResumeAward = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeAward';
+  const TARGET_QUERY_KEY = categoryKeys.award;
   return useMutation({
     mutationKey: ['postAward'],
     mutationFn: postResumeAward,
     onMutate: async (newAward) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousAwards = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Award[]) => [...old, newAward]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousAwards = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Award[]) => [...old, newAward]);
       return { previousAwards };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newAward, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousAwards);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousAwards);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/create/usePostResumeAward.ts
+++ b/src/queries/resume/create/usePostResumeAward.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeAward } from '~/api/resume/create/postResumeAward';
 import { Award } from '~/types/award';
 
-export const usePostResumeAward = () => {
+export const usePostResumeAward = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.award;
+  const TARGET_QUERY_KEY = categoryKeys.award(resumeId);
   return useMutation({
     mutationKey: ['postAward'],
     mutationFn: postResumeAward,

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
 import Career from '~/types/career';
 
 export const usePostResumeCareer = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeCareer';
+  const TARGET_QUERY_KEY = categoryKeys.career;
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeCareer,
     onMutate: async (newCareer) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousCareers = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Career[]) => [...old, newCareer]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousCareers = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Career[]) => [...old, newCareer]);
       return { previousCareers };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newCareer, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousCareers);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousCareers);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/create/usePostResumeCareer.ts
+++ b/src/queries/resume/create/usePostResumeCareer.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeCareer } from '~/api/resume/create/postResumeCareer';
 import Career from '~/types/career';
 
-export const usePostResumeCareer = () => {
+export const usePostResumeCareer = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.career;
+  const TARGET_QUERY_KEY = categoryKeys.career(resumeId);
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeCareer,

--- a/src/queries/resume/create/usePostResumeLanguage.ts
+++ b/src/queries/resume/create/usePostResumeLanguage.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeLanguage } from '~/api/resume/create/postResumeLanguage';
 import { Language } from '~/types/language';
 
 export const usePostResumeLanguage = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeLanguage';
+  const TARGET_QUERY_KEY = categoryKeys.language;
   return useMutation({
     mutationKey: ['postLanguage'],
     mutationFn: postResumeLanguage,
     onMutate: async (newLanguage) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousLanguages = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Language[]) => [...old, newLanguage]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousLanguages = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Language[]) => [...old, newLanguage]);
       return { previousLanguages };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newLanguage, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousLanguages);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousLanguages);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/create/usePostResumeLanguage.ts
+++ b/src/queries/resume/create/usePostResumeLanguage.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeLanguage } from '~/api/resume/create/postResumeLanguage';
 import { Language } from '~/types/language';
 
-export const usePostResumeLanguage = () => {
+export const usePostResumeLanguage = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.language;
+  const TARGET_QUERY_KEY = categoryKeys.language(resumeId);
   return useMutation({
     mutationKey: ['postLanguage'],
     mutationFn: postResumeLanguage,

--- a/src/queries/resume/create/usePostResumeTraining.ts
+++ b/src/queries/resume/create/usePostResumeTraining.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeTraining } from '~/api/resume/create/postResumeTraining';
 import { Activity } from '~/types/activity';
 
 export const usePostResumeTraining = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeTraining';
+  const TARGET_QUERY_KEY = categoryKeys.training;
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeTraining,
     onMutate: async (newProject) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousProjects = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Activity[]) => [...old, newProject]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousProjects = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Activity[]) => [...old, newProject]);
       return { previousProjects };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newProject, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousProjects);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousProjects);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/create/usePostResumeTraining.ts
+++ b/src/queries/resume/create/usePostResumeTraining.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeTraining } from '~/api/resume/create/postResumeTraining';
 import { Activity } from '~/types/activity';
 
-export const usePostResumeTraining = () => {
+export const usePostResumeTraining = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.training;
+  const TARGET_QUERY_KEY = categoryKeys.training(resumeId);
   return useMutation({
     mutationKey: ['postCareer'],
     mutationFn: postResumeTraining,

--- a/src/queries/resume/create/usePostRusumeProject.ts
+++ b/src/queries/resume/create/usePostRusumeProject.ts
@@ -4,9 +4,9 @@ import { categoryKeys } from '../categoryKeys.const';
 import { postResumeProject } from '~/api/resume/create/postResumeProject';
 import { Project } from '~/types/project';
 
-export const usePostResumeProject = () => {
+export const usePostResumeProject = (resumeId: string) => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = categoryKeys.project;
+  const TARGET_QUERY_KEY = categoryKeys.project(resumeId);
   return useMutation({
     mutationKey: ['postProject'],
     mutationFn: postResumeProject,

--- a/src/queries/resume/create/usePostRusumeProject.ts
+++ b/src/queries/resume/create/usePostRusumeProject.ts
@@ -1,27 +1,28 @@
 import { useMutation } from '@tanstack/react-query';
 import { useQueryClient } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { postResumeProject } from '~/api/resume/create/postResumeProject';
 import { Project } from '~/types/project';
 
 export const usePostResumeProject = () => {
   const queryClient = useQueryClient();
-  const TARGET_QUERY_KEY = 'getResumeProject';
+  const TARGET_QUERY_KEY = categoryKeys.project;
   return useMutation({
     mutationKey: ['postProject'],
     mutationFn: postResumeProject,
     onMutate: async (newProject) => {
-      await queryClient.cancelQueries({ queryKey: [TARGET_QUERY_KEY] });
-      const previousProjects = queryClient.getQueryData([TARGET_QUERY_KEY]);
-      queryClient.setQueryData([TARGET_QUERY_KEY], (old: Project[]) => [...old, newProject]);
+      await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
+      const previousProjects = queryClient.getQueryData(TARGET_QUERY_KEY);
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: Project[]) => [...old, newProject]);
       return { previousProjects };
     },
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     onError: (err, newProject, context) => {
-      queryClient.setQueryData([TARGET_QUERY_KEY], context?.previousProjects);
+      queryClient.setQueryData(TARGET_QUERY_KEY, context?.previousProjects);
     },
     onSettled: () => {
-      queryClient.invalidateQueries({ queryKey: [TARGET_QUERY_KEY] });
+      queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
 };

--- a/src/queries/resume/details/useGetResumeActivities.ts
+++ b/src/queries/resume/details/useGetResumeActivities.ts
@@ -4,7 +4,7 @@ import { GetResumeActivities, getResumeActivities } from '~/api/resume/details/g
 
 export const useGetResumeActivities = ({ resumeId }: GetResumeActivities) => {
   return useQuery({
-    queryKey: categoryKeys.activities,
+    queryKey: categoryKeys.activities(resumeId),
     queryFn: () => getResumeActivities({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeActivities.ts
+++ b/src/queries/resume/details/useGetResumeActivities.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeActivities, getResumeActivities } from '~/api/resume/details/getResumeActivities';
 
 export const useGetResumeActivities = ({ resumeId }: GetResumeActivities) => {
   return useQuery({
-    queryKey: ['getResumeActivities'],
+    queryKey: categoryKeys.activities,
     queryFn: () => getResumeActivities({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeActivities.ts
+++ b/src/queries/resume/details/useGetResumeActivities.ts
@@ -4,7 +4,7 @@ import { GetResumeActivities, getResumeActivities } from '~/api/resume/details/g
 
 export const useGetResumeActivities = ({ resumeId }: GetResumeActivities) => {
   return useQuery({
-    queryKey: categoryKeys.activities(resumeId),
+    queryKey: categoryKeys.activity(resumeId),
     queryFn: () => getResumeActivities({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeAward.ts
+++ b/src/queries/resume/details/useGetResumeAward.ts
@@ -4,7 +4,7 @@ import { GetResumeAward, getResumeAward } from '~/api/resume/details/getResumeAw
 
 export const useGetResumeAward = ({ resumeId }: GetResumeAward) => {
   return useQuery({
-    queryKey: categoryKeys.award,
+    queryKey: categoryKeys.award(resumeId),
     queryFn: () => getResumeAward({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeAward.ts
+++ b/src/queries/resume/details/useGetResumeAward.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeAward, getResumeAward } from '~/api/resume/details/getResumeAward';
 
 export const useGetResumeAward = ({ resumeId }: GetResumeAward) => {
   return useQuery({
-    queryKey: ['getResumeAward'],
+    queryKey: categoryKeys.award,
     queryFn: () => getResumeAward({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeCareer.ts
+++ b/src/queries/resume/details/useGetResumeCareer.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeCareer, getResumeCareer } from '~/api/resume/details/getResumeCareer';
 
 export const useGetResumeCareer = ({ resumeId }: GetResumeCareer) => {
   return useQuery({
-    queryKey: ['getResumeCareer'],
+    queryKey: categoryKeys.career,
     queryFn: () => getResumeCareer({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeCareer.ts
+++ b/src/queries/resume/details/useGetResumeCareer.ts
@@ -4,7 +4,7 @@ import { GetResumeCareer, getResumeCareer } from '~/api/resume/details/getResume
 
 export const useGetResumeCareer = ({ resumeId }: GetResumeCareer) => {
   return useQuery({
-    queryKey: categoryKeys.career,
+    queryKey: categoryKeys.career(resumeId),
     queryFn: () => getResumeCareer({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeLanguage.ts
+++ b/src/queries/resume/details/useGetResumeLanguage.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeLanguage, getResumeLanguage } from '~/api/resume/details/getResumeLanguage';
 
 export const useGetResumeLanguage = ({ resumeId }: GetResumeLanguage) => {
   return useQuery({
-    queryKey: ['getResumeLanguage'],
+    queryKey: categoryKeys.language,
     queryFn: () => getResumeLanguage({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeLanguage.ts
+++ b/src/queries/resume/details/useGetResumeLanguage.ts
@@ -4,7 +4,7 @@ import { GetResumeLanguage, getResumeLanguage } from '~/api/resume/details/getRe
 
 export const useGetResumeLanguage = ({ resumeId }: GetResumeLanguage) => {
   return useQuery({
-    queryKey: categoryKeys.language,
+    queryKey: categoryKeys.language(resumeId),
     queryFn: () => getResumeLanguage({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeProject.ts
+++ b/src/queries/resume/details/useGetResumeProject.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeProject, getResumeProject } from '~/api/resume/details/getResumeProject';
 
 export const useGetResumeProject = ({ resumeId }: GetResumeProject) => {
   return useQuery({
-    queryKey: ['getResumeProject'],
+    queryKey: categoryKeys.project,
     queryFn: () => getResumeProject({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeProject.ts
+++ b/src/queries/resume/details/useGetResumeProject.ts
@@ -4,7 +4,7 @@ import { GetResumeProject, getResumeProject } from '~/api/resume/details/getResu
 
 export const useGetResumeProject = ({ resumeId }: GetResumeProject) => {
   return useQuery({
-    queryKey: categoryKeys.project,
+    queryKey: categoryKeys.project(resumeId),
     queryFn: () => getResumeProject({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeTraining.ts
+++ b/src/queries/resume/details/useGetResumeTraining.ts
@@ -4,7 +4,7 @@ import { GetResumeTraining, getResumeTraining } from '~/api/resume/details/getRe
 
 export const useGetResumeTraining = ({ resumeId }: GetResumeTraining) => {
   return useQuery({
-    queryKey: categoryKeys.training,
+    queryKey: categoryKeys.training(resumeId),
     queryFn: () => getResumeTraining({ resumeId }),
     enabled: !!resumeId,
   });

--- a/src/queries/resume/details/useGetResumeTraining.ts
+++ b/src/queries/resume/details/useGetResumeTraining.ts
@@ -1,9 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
+import { categoryKeys } from '../categoryKeys.const';
 import { GetResumeTraining, getResumeTraining } from '~/api/resume/details/getResumeTraining';
 
 export const useGetResumeTraining = ({ resumeId }: GetResumeTraining) => {
   return useQuery({
-    queryKey: ['getResumeTraining'],
+    queryKey: categoryKeys.training,
     queryFn: () => getResumeTraining({ resumeId }),
     enabled: !!resumeId,
   });


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 카테고리 데이터를 불러오는 useQuery를 카테고리 저장, 수정의 onMutate에서 사용하는데,
- 기존 하드코딩으로 박아뒀던 값들을 객체 상수로 바꿔줬습니다.
- 현재 카테고리 수정 기능 작업 중인데, patch용 mutation의 onMutate에도 쿼리 키를 사용해야 해서 더 이상 상수 처리를 미루면 안 될 것 같아 핫픽스 이슈 추가해 PR 올립니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- [지호님 @backward99 이 리뷰에서 공유해주신 자료](https://www.zigae.com/react-query-key/)를 참고했는데, 맞게 적용한 건지 모르겠네요.

## 🔎 PR포인트 및 궁금한 점
