### PR TITLE
Gmmq 440 feat: 마이페이지 멘토 - 각 이벤트 별 이력서 컴포넌트 개발

### DIFF
--- a/src/components/organisms/Profile/EventItem.tsx
+++ b/src/components/organisms/Profile/EventItem.tsx
@@ -11,7 +11,6 @@ import {
 } from '@chakra-ui/react';
 import { v4 as uuidv4 } from 'uuid';
 import ResumeList from './ResumeList';
-import { AccordionToggle } from '~/components/atoms/AccordionToggle';
 import { EventResume, EventTime } from '~/types/event';
 import { formatDate } from '~/utils/formatDate';
 
@@ -85,11 +84,9 @@ const EventItem = ({
             <Spacer />
             <Text>{`신청 인원 ${currentApplicantCount} / ${maximumCount}`}</Text>
           </Flex>
-          <AccordionPanel
-            px={0}
-            // py={}
-          >
+          <AccordionPanel p={0}>
             <Flex
+              mt={'1rem'}
               direction={'column'}
               gap={'1.37rem'}
             >

--- a/src/components/organisms/Profile/EventItem.tsx
+++ b/src/components/organisms/Profile/EventItem.tsx
@@ -1,5 +1,16 @@
-import { Flex, Text } from '@chakra-ui/react';
+import {
+  Accordion,
+  AccordionButton,
+  AccordionIcon,
+  AccordionItem,
+  AccordionPanel,
+  Box,
+  Flex,
+  Spacer,
+  Text,
+} from '@chakra-ui/react';
 import { v4 as uuidv4 } from 'uuid';
+import ResumeList from './ResumeList';
 import { AccordionToggle } from '~/components/atoms/AccordionToggle';
 import { EventResume, EventTime } from '~/types/event';
 import { formatDate } from '~/utils/formatDate';
@@ -39,25 +50,59 @@ const EventItem = ({
             <Text>첨삭 종료일</Text>
             <Text>{formatDate(timeInfo.endDate)}</Text>
           </Flex>
-          <Flex justifyContent={'space-between'}>
-            <Text>신청 인원</Text>
-            <Text>{`${currentApplicantCount} / ${maximumCount}`}</Text>
-          </Flex>
         </Flex>
       </Flex>
-      <Flex
-        color={'gray.800'}
-        fontSize={'0.875rem'}
+      <Accordion
         mt={'2.37rem'}
-        justifyContent={'space-between'}
+        w={'full'}
+        allowToggle
       >
-        <AccordionToggle text="신청이력서 3건">
-          {/* //TODO: 다른 이력서 정보로 진행 */}
-          {resumes.map((resume) => (
-            <Text key={uuidv4()}>{resume.resumeId}</Text>
-          ))}
-        </AccordionToggle>
-      </Flex>
+        <AccordionItem
+          border={'none'}
+          px={0}
+          w={'full'}
+        >
+          <Flex>
+            <AccordionButton
+              w={'7rem'}
+              _hover={{ bg: 'none' }}
+              p={0}
+            >
+              <Box
+                w={'full'}
+                as="span"
+                flex={1}
+                textAlign={'left'}
+                fontSize={'0.875rem'}
+              >
+                {`신청이력서 ${resumes.length}건`}
+              </Box>
+              <AccordionIcon
+                marginLeft={'0.37rem'}
+                fontSize={'0.875rem'}
+              />
+            </AccordionButton>
+            <Spacer />
+            <Text>{`신청 인원 ${currentApplicantCount} / ${maximumCount}`}</Text>
+          </Flex>
+          <AccordionPanel
+            px={0}
+            // py={}
+          >
+            <Flex
+              direction={'column'}
+              gap={'1.37rem'}
+            >
+              {resumes.map((resume) => (
+                <ResumeList
+                  key={uuidv4()}
+                  resume={resume}
+                />
+              ))}
+            </Flex>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
     </>
   );
 };

--- a/src/components/organisms/Profile/EventProfile.tsx
+++ b/src/components/organisms/Profile/EventProfile.tsx
@@ -30,6 +30,7 @@ const EventProfile = ({ events }: EventProfile) => {
           <Text
             fontSize={'0.85rem'}
             color={'gray.700'}
+            fontWeight={700}
           >
             {`총 ${events.length}건`}
           </Text>

--- a/src/components/organisms/Profile/ResumeList.tsx
+++ b/src/components/organisms/Profile/ResumeList.tsx
@@ -1,0 +1,72 @@
+import { Box, Flex, Icon, Spacer, Text } from '@chakra-ui/react';
+import { VscNote } from 'react-icons/vsc';
+import { EventResume } from '~/types/event';
+
+type ResumeListProps = {
+  resume: EventResume;
+};
+
+const ResumeList = ({ resume }: ResumeListProps) => {
+  return (
+    <Flex gap={'0.75rem'}>
+      <Box
+        flexGrow={1}
+        borderRadius={'0.3125rem'}
+        fontSize={'0.875rem'}
+        bg={'gray.200'}
+        p={'0.63rem 0.87rem'}
+      >
+        <Flex
+          gap={'0.88rem'}
+          alignItems={'center'}
+        >
+          <Icon
+            color={'primary.900'}
+            as={VscNote}
+            w={'auto'}
+          />
+          <Text
+            w={'5rem'}
+            borderRight={'1px'}
+            borderColor={'gray.300'}
+            color={'gray.900'}
+            as="span"
+          >
+            {resume.menteeName}
+          </Text>
+          <Text
+            color={'gray.700'}
+            as="span"
+          >
+            {resume.resumeTitle}
+          </Text>
+          <Spacer />
+          <Text
+            color={'gray.500'}
+            as="span"
+          >
+            {resume.resumeId}
+          </Text>
+        </Flex>
+      </Box>
+      <Flex
+        justifyContent={'center'}
+        alignItems={'center'}
+        w={'3.375rem'}
+        borderRadius={'0.3125rem'}
+        fontSize={'0.75rem'}
+        bg={'primary.700'}
+        h={'2.5rem'}
+      >
+        <Text
+          as="span"
+          color={'white'}
+        >
+          진행 중{/* {resume.progressStatus} */}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ResumeList;

--- a/src/components/organisms/Profile/ResumeList.tsx
+++ b/src/components/organisms/Profile/ResumeList.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Icon, Spacer, Text } from '@chakra-ui/react';
-import { VscNote } from 'react-icons/vsc';
+import { MdOutlineArticle } from 'react-icons/md';
 import { EventResume } from '~/types/event';
 
 type ResumeListProps = {
@@ -22,7 +22,7 @@ const ResumeList = ({ resume }: ResumeListProps) => {
         >
           <Icon
             color={'primary.900'}
-            as={VscNote}
+            as={MdOutlineArticle}
             w={'auto'}
           />
           <Text


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/a60e81e8-2b11-4832-ab5e-b5df8c9ddb7f)

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
Gmmq 440 feat: 마이페이지 멘토 - 각 이벤트 별 이력서 컴포넌트 개발을 진행했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
임의로 타입을 정한거라서 들어가는 글 들은 api연결 과정에서 추가적으로 수정해야할 것 같습니다.

아코디언에서 text 부분이 늘어나지 않고, 인원현황과 같은 라인에 있어야해서 만들어둔 컴포넌트는 사용하지 못했습니다.

## 🔎 PR포인트 및 궁금한 점
