### PR TITLE
Gmmq 545 fix: 희망 직무, 보유 기술이 없을 때 UI 렌더링 하지 않기

### DIFF
--- a/src/api/resume/create/postResumeLink.ts
+++ b/src/api/resume/create/postResumeLink.ts
@@ -7,14 +7,11 @@ import { getCookie } from '~/utils/cookie';
 
 type postResumeLink = { resumeId: string; referenceLink: ReferenceLink };
 
-/* TODO 이력서의 참고 링크를 저장하는 api가 필요! */
-const api주소 = '';
-
 export const postResumeLink = async ({ resumeId, referenceLink }: postResumeLink) => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
 
   try {
-    const { data } = await resumeMeAxios.post(`v1/resumes/${resumeId}/${api주소}`, referenceLink, {
+    const { data } = await resumeMeAxios.post(`v1/resumes/${resumeId}/links`, referenceLink, {
       headers: {
         /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
         Authorization: accessToken,

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -81,15 +81,18 @@ const ResumeDetailTemplate = () => {
                 >
                   {data.basic?.ownerInfo.name}
                 </Text>
-                <Label
-                  width={'fit-content'}
-                  fontSize={'sm'}
-                  bg="green.500"
-                  color={'gray.100'}
-                  px={5}
-                >
-                  {data.basic?.position}
-                </Label>
+                {data.basic?.position && (
+                  <Label
+                    width={'fit-content'}
+                    fontSize={'sm'}
+                    bg="green.500"
+                    color={'gray.100'}
+                    px={5}
+                  >
+                    {data.basic.position}
+                  </Label>
+                )}
+
                 <Flex
                   gap={4}
                   align={'center'}
@@ -98,7 +101,7 @@ const ResumeDetailTemplate = () => {
                   <Text>{data.basic?.ownerInfo.phoneNumber}</Text>
                 </Flex>
               </Flex>
-              {data.links && (
+              {data.links && data.links?.length > 0 && (
                 <Flex
                   direction={'column'}
                   align={'start'}
@@ -124,7 +127,7 @@ const ResumeDetailTemplate = () => {
               mt={'3%'}
               flex={1}
             >
-              {data.basic?.skills && (
+              {data.basic?.skills && data.basic?.skills?.length > 0 && (
                 <Flex
                   direction={'column'}
                   align={'flex-end'}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/50bb2f26-1d07-4363-af0d-ffac01dfaca0)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 희망 직무(position), 보유 기술(skills)에 데이터가 없을 때는 UI 블록을 렌더링하지 않도록 했습니다.
- **스크린샷에 보유 기술이 렌더링되어 있는 것은 현재 서버에서 skills가 비어있을 때 `[""]` 와 같이 빈 문자열을 주기 때문입니다.**
- **이 부분이 수정되어서 빈 배열 `[]`을 반환하면 제대로 동작합니다. (테스트 완료)**

### 번외
- 참고 링크 api 부분 수정했습니다. (중요하지 않아용)

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
