### PR TITLE
Gmmq 464 feat: 이벤트 신청 페이지 UI + 이력서 리스트 불러오기 연동

### DIFF
--- a/src/api/resume/getMyResumes.ts
+++ b/src/api/resume/getMyResumes.ts
@@ -1,0 +1,14 @@
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { ResumeListItem } from '~/types/resume/resumeListItem';
+import { getCookie } from '~/utils/cookie';
+
+export const getMyResumes = async (): Promise<ResumeListItem[]> => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+  const { data } = await resumeMeAxios.get(`/v1/resumes`, {
+    headers: {
+      Authorization: accessToken,
+    },
+  });
+  return data;
+};

--- a/src/components/atoms/Spinner/Spinner.tsx
+++ b/src/components/atoms/Spinner/Spinner.tsx
@@ -1,13 +1,25 @@
-import { Spinner as ChakraSpinner, SpinnerProps as ChakraSpinnerProps } from '@chakra-ui/react';
+import {
+  Spinner as ChakraSpinner,
+  SpinnerProps as ChakraSpinnerProps,
+  Flex,
+} from '@chakra-ui/react';
 
 const Spinner = ({ ...props }: ChakraSpinnerProps) => {
   return (
-    <ChakraSpinner
-      color="primary.900"
-      thickness="4px"
-      size={'xl'}
-      {...props}
-    />
+    <Flex
+      w={'full'}
+      h={'full'}
+      justify={'center'}
+      align={'center'}
+    >
+      <ChakraSpinner
+        color="primary.900"
+        thickness="4px"
+        size={'xl'}
+        m={'0 auto'}
+        {...props}
+      />
+    </Flex>
   );
 };
 

--- a/src/components/molecules/MentorProfile/MentorProfile.tsx
+++ b/src/components/molecules/MentorProfile/MentorProfile.tsx
@@ -8,9 +8,10 @@ import { ReadMentor } from '~/types/mentor';
 type MentorProfileProps = {
   mentor: ReadMentor;
   event: ReadEvent;
+  onApply: () => void;
 };
 
-const MentorProfile = ({ mentor, event }: MentorProfileProps) => {
+const MentorProfile = ({ mentor, event, onApply }: MentorProfileProps) => {
   const { nickname, introduce, imageUrl } = mentor;
 
   return (
@@ -70,7 +71,12 @@ const MentorProfile = ({ mentor, event }: MentorProfileProps) => {
           </Text>
         </Flex>
       </Flex>
-      <Button size={'full'}>신청하기</Button>
+      <Button
+        size={'full'}
+        onClick={onApply}
+      >
+        신청하기
+      </Button>
     </VStack>
   );
 };

--- a/src/components/molecules/MentorProfile/index.stories.tsx
+++ b/src/components/molecules/MentorProfile/index.stories.tsx
@@ -49,6 +49,7 @@ export const Default = () => {
     <MentorProfile
       mentor={DUMMY_DATA.mentor}
       event={DUMMY_DATA.event}
+      onApply={() => {}}
     />
   );
 };

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -2,11 +2,9 @@ import {
   Modal as ChakraModal,
   ModalOverlay,
   ModalContent,
-  ModalFooter,
   ModalHeader,
   ModalCloseButton,
   ModalBody,
-  Button,
   ModalContentProps,
 } from '@chakra-ui/react';
 
@@ -24,7 +22,6 @@ const Modal = ({
   isOpen,
   onClose,
   hasCloseButton = true,
-  hasFooter = false,
   size = 'xl',
   title,
   children,
@@ -46,22 +43,6 @@ const Modal = ({
         {title && <ModalHeader paddingTop={0}>{title}</ModalHeader>}
         {hasCloseButton && <ModalCloseButton p={'1.5rem'} />}
         <ModalBody p={0}>{children}</ModalBody>
-        {hasFooter && (
-          <ModalFooter
-            paddingBottom={0}
-            px={0}
-          >
-            {/*FIXME - 공통 버튼 컴포넌트로 대체하기 */}
-            <Button
-              colorScheme="blue"
-              mr={3}
-              onClick={onClose}
-            >
-              Close
-            </Button>
-            <Button variant="ghost">Secondary Action</Button>
-          </ModalFooter>
-        )}
       </ModalContent>
     </ChakraModal>
   );

--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -7,10 +7,10 @@ import {
   ModalCloseButton,
   ModalBody,
   Button,
-  ModalBodyProps,
+  ModalContentProps,
 } from '@chakra-ui/react';
 
-export type ModalProps = ModalBodyProps & {
+export type ModalProps = {
   isOpen: boolean;
   onClose: () => void;
   hasCloseButton?: boolean;
@@ -18,7 +18,7 @@ export type ModalProps = ModalBodyProps & {
   size?: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'full';
   title?: string;
   children?: React.ReactNode;
-};
+} & ModalContentProps;
 
 const Modal = ({
   isOpen,
@@ -28,7 +28,7 @@ const Modal = ({
   size = 'xl',
   title,
   children,
-  ...modalBodyProps
+  ...modalContentProps
 }: ModalProps) => {
   return (
     <ChakraModal
@@ -41,10 +41,11 @@ const Modal = ({
       <ModalContent
         borderRadius={'1.5rem'}
         p={'1.5rem'}
+        {...modalContentProps}
       >
         {title && <ModalHeader paddingTop={0}>{title}</ModalHeader>}
         {hasCloseButton && <ModalCloseButton p={'1.5rem'} />}
-        <ModalBody {...modalBodyProps}>{children}</ModalBody>
+        <ModalBody p={0}>{children}</ModalBody>
         {hasFooter && (
           <ModalFooter
             paddingBottom={0}

--- a/src/components/molecules/ResumeListItem/ResumeListItem.tsx
+++ b/src/components/molecules/ResumeListItem/ResumeListItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
-import { Badge } from '~/components/atoms/Badge';
+import { Label } from '~/components/atoms/Label';
 import { ResumeListItem } from '~/types/resume/resumeListItem';
 
 type ResumeListItemProps = {
@@ -18,7 +18,12 @@ const ResumeListItem = ({ data: { title, modifiedAt } }: ResumeListItemProps) =>
             {new Date(modifiedAt).toLocaleString()}
           </Text>
           {/**FIXME - 이력서 희망 직무 api 데이터 추가되면 대체하기 */}
-          <Badge>{'이력서 희망 직무'}</Badge>
+          <Label
+            bg={'gray.300'}
+            color={'gray.700'}
+          >
+            {'이력서 희망 직무'}
+          </Label>
         </Flex>
         <Text
           fontSize={'1.125rem'}

--- a/src/components/molecules/ResumeListItem/ResumeListItem.tsx
+++ b/src/components/molecules/ResumeListItem/ResumeListItem.tsx
@@ -1,0 +1,35 @@
+import { Box, Flex, Text } from '@chakra-ui/react';
+import { Badge } from '~/components/atoms/Badge';
+import { ResumeListItem } from '~/types/resume/resumeListItem';
+
+type ResumeListItemProps = {
+  data: ResumeListItem;
+};
+
+const ResumeListItem = ({ data: { title, modifiedAt } }: ResumeListItemProps) => {
+  return (
+    <Box>
+      <Flex direction={'column'}>
+        <Flex justifyContent={'space-between'}>
+          <Text
+            color={'gray.500'}
+            fontSize={'0.75rem'}
+          >
+            {new Date(modifiedAt).toLocaleString()}
+          </Text>
+          {/**FIXME - 이력서 희망 직무 api 데이터 추가되면 대체하기 */}
+          <Badge>{'이력서 희망 직무'}</Badge>
+        </Flex>
+        <Text
+          fontSize={'1.125rem'}
+          fontWeight={'600'}
+        >
+          {title}
+        </Text>
+        {/**TODO - 메모 컴포넌트 */}
+      </Flex>
+    </Box>
+  );
+};
+
+export default ResumeListItem;

--- a/src/components/molecules/ResumeListItem/index.stories.tsx
+++ b/src/components/molecules/ResumeListItem/index.stories.tsx
@@ -1,0 +1,22 @@
+import { Meta } from '@storybook/react';
+import { ResumeListItem } from '.';
+
+const meta = {
+  title: 'Resumeme/Components/ResumeListItem',
+  tags: ['autodocs'],
+  component: ResumeListItem,
+} satisfies Meta<typeof ResumeListItem>;
+
+export default meta;
+
+export const Default = () => {
+  return (
+    <ResumeListItem
+      data={{
+        id: 1,
+        title: 'title1',
+        modifiedAt: '2023-11-17',
+      }}
+    />
+  );
+};

--- a/src/components/molecules/ResumeListItem/index.ts
+++ b/src/components/molecules/ResumeListItem/index.ts
@@ -1,0 +1,1 @@
+export { default as ResumeListItem } from './ResumeListItem';

--- a/src/components/organisms/RadioCardGroup/RadioCard.tsx
+++ b/src/components/organisms/RadioCardGroup/RadioCard.tsx
@@ -22,6 +22,7 @@ const RadioCard = ({ children, borderBoxStyle, ...props }: RadioCardProps) => {
         _checked={{
           borderColor: 'primary.900',
           color: 'primary.900',
+          border: '2px',
         }}
         cursor={'pointer'}
       >

--- a/src/components/organisms/RadioCardGroup/RadioCard.tsx
+++ b/src/components/organisms/RadioCardGroup/RadioCard.tsx
@@ -1,5 +1,4 @@
 import { Box, useRadio } from '@chakra-ui/react';
-import { forwardRef } from 'react';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { BorderBoxProps } from '~/components/atoms/BorderBox/BorderBox';
 
@@ -8,7 +7,7 @@ type RadioCardProps = {
   borderBoxStyle?: BorderBoxProps;
 };
 
-const RadioCard = forwardRef(({ children, borderBoxStyle, ...props }: RadioCardProps) => {
+const RadioCard = ({ children, borderBoxStyle, ...props }: RadioCardProps) => {
   const { getInputProps, getRadioProps } = useRadio(props);
   const inputProps = getInputProps();
   const radioProps = getRadioProps();
@@ -30,6 +29,6 @@ const RadioCard = forwardRef(({ children, borderBoxStyle, ...props }: RadioCardP
       </BorderBox>
     </Box>
   );
-});
+};
 
 export default RadioCard;

--- a/src/components/organisms/RadioCardGroup/RadioCardGroup.tsx
+++ b/src/components/organisms/RadioCardGroup/RadioCardGroup.tsx
@@ -1,8 +1,8 @@
-import { Box, BoxProps, Flex, FormErrorMessage, HStack, useRadioGroup } from '@chakra-ui/react';
+import { Box, BoxProps, Flex, FormErrorMessage, useRadioGroup } from '@chakra-ui/react';
 import { FieldError, UseFormRegisterReturn } from 'react-hook-form';
 import RadioCard from './RadioCard';
 
-export type RadioOption<T extends string> = {
+export type RadioOption<T extends string = string> = {
   value: T;
   children: React.ReactNode;
 };
@@ -13,6 +13,7 @@ type RadioCardGroupProps<T extends string> = {
   defaultValue: string;
   register: UseFormRegisterReturn;
   error?: Partial<FieldError>;
+  direction?: 'row' | 'column';
 } & BoxProps;
 
 const RadioCardGroup = ({
@@ -21,6 +22,7 @@ const RadioCardGroup = ({
   defaultValue,
   register,
   error,
+  direction = 'row',
   ...boxProps
 }: RadioCardGroupProps<string>) => {
   const { getRootProps, getRadioProps } = useRadioGroup({
@@ -32,7 +34,10 @@ const RadioCardGroup = ({
 
   return (
     <Flex direction={'column'}>
-      <HStack
+      <Flex
+        direction={direction}
+        w={'full'}
+        gap={'0.5rem'}
         {...group}
         {...boxProps}
       >
@@ -41,7 +46,7 @@ const RadioCardGroup = ({
           return (
             <Box
               key={value}
-              w={`${100 / options.length}%`}
+              flexBasis={`${100 / options.length}%`}
               h={'full'}
               {...register}
             >
@@ -49,7 +54,7 @@ const RadioCardGroup = ({
             </Box>
           );
         })}
-      </HStack>
+      </Flex>
       {error && <FormErrorMessage>{error.message as string}</FormErrorMessage>}
     </Flex>
   );

--- a/src/components/organisms/RadioCardGroup/RadioCardGroup.tsx
+++ b/src/components/organisms/RadioCardGroup/RadioCardGroup.tsx
@@ -23,7 +23,7 @@ const RadioCardGroup = ({
   register,
   error,
   direction = 'row',
-  ...boxProps
+  ...cardBoxProps
 }: RadioCardGroupProps<string>) => {
   const { getRootProps, getRadioProps } = useRadioGroup({
     name: formName,
@@ -39,7 +39,6 @@ const RadioCardGroup = ({
         w={'full'}
         gap={'0.5rem'}
         {...group}
-        {...boxProps}
       >
         {options.map(({ value, children }: RadioOption<string>) => {
           const radioProps = getRadioProps({ value });
@@ -50,7 +49,12 @@ const RadioCardGroup = ({
               h={'full'}
               {...register}
             >
-              <RadioCard {...radioProps}>{children}</RadioCard>
+              <RadioCard
+                {...radioProps}
+                borderBoxStyle={cardBoxProps}
+              >
+                {children}
+              </RadioCard>
             </Box>
           );
         })}

--- a/src/components/organisms/ResumeSelect/ResumeSelect.tsx
+++ b/src/components/organisms/ResumeSelect/ResumeSelect.tsx
@@ -1,21 +1,13 @@
 import { Flex, HStack, Text } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import RadioCardGroup from '../RadioCardGroup/RadioCardGroup';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
 import { ResumeListItem } from '~/components/molecules/ResumeListItem';
-import RadioCardGroup, { RadioOption } from '~/components/organisms/RadioCardGroup/RadioCardGroup';
 import { useGetMyResumes } from '~/queries/resume/useGetMyResumes';
 
-const ResumeSelectTemplate = () => {
+const ResumeSelect = ({ onCancel }: { onCancel: () => void }) => {
   const { data } = useGetMyResumes();
-  const resumeOptions: RadioOption[] = [];
-  data.map((data) => {
-    const option = {
-      value: data.id.toString(),
-      children: <ResumeListItem data={data} />,
-    };
-    resumeOptions.push(option);
-  });
   const { register, handleSubmit } = useForm<{ resumeId: string }>();
   const onSubmit: SubmitHandler<{ resumeId: string }> = (values) => {
     /**TODO - 이벤트 신청 api 연결 */
@@ -24,16 +16,8 @@ const ResumeSelectTemplate = () => {
   return (
     <>
       <Text
-        color={'gray.900'}
-        fontWeight={'600'}
-        fontSize={'1.5rem'}
-        mb={'2rem'}
-      >
-        첨삭 신청하기
-      </Text>
-      <Text
         color={'gray.800'}
-        fontSize={'1.5rem'}
+        fontSize={'1.3rem'}
         fontWeight={'600'}
         mb={'1rem'}
       >
@@ -47,23 +31,27 @@ const ResumeSelectTemplate = () => {
         >
           <BorderBox
             w={'full'}
-            minH={'30rem'}
-            maxH={'90vh'}
+            h={'30rem'}
             overflow={'auto'}
           >
             <RadioCardGroup
-              options={resumeOptions}
+              options={data.map((data) => ({
+                value: data.id.toString(),
+                children: <ResumeListItem data={data} />,
+              }))}
               formName="resume"
               defaultValue={data[0].id.toString()}
               register={{ ...register('resumeId') }}
               direction="column"
               overflow={'auto'}
+              borderRadius={'0.625rem'}
             />
           </BorderBox>
           <HStack alignSelf={'flex-end'}>
             <Button
-              size={'md'}
+              size={'sm'}
               variant={'cancel'}
+              onClick={onCancel}
             >
               취소
             </Button>
@@ -80,4 +68,4 @@ const ResumeSelectTemplate = () => {
   );
 };
 
-export default ResumeSelectTemplate;
+export default ResumeSelect;

--- a/src/components/organisms/ResumeSelect/index.stories.tsx
+++ b/src/components/organisms/ResumeSelect/index.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta } from '@storybook/react';
+import { ResumeSelect } from '.';
+
+const meta = {
+  title: 'Resumeme/Components/ResumeSelect ',
+  component: ResumeSelect,
+  tags: ['autodocs'],
+} satisfies Meta<typeof ResumeSelect>;
+
+export default meta;
+
+export const Default = () => {
+  return <ResumeSelect onCancel={() => {}} />;
+};

--- a/src/components/organisms/ResumeSelect/index.ts
+++ b/src/components/organisms/ResumeSelect/index.ts
@@ -1,0 +1,1 @@
+export { default as ResumeSelect } from './ResumeSelect';

--- a/src/components/templates/ResumeSelectTemplate/ResumeSelectTemplate.tsx
+++ b/src/components/templates/ResumeSelectTemplate/ResumeSelectTemplate.tsx
@@ -67,7 +67,12 @@ const ResumeSelectTemplate = () => {
             >
               취소
             </Button>
-            <Button size={'md'}>신청하기</Button>
+            <Button
+              size={'md'}
+              type="submit"
+            >
+              신청하기
+            </Button>
           </HStack>
         </Flex>
       </form>

--- a/src/components/templates/ResumeSelectTemplate/ResumeSelectTemplate.tsx
+++ b/src/components/templates/ResumeSelectTemplate/ResumeSelectTemplate.tsx
@@ -1,0 +1,78 @@
+import { Flex, HStack, Text } from '@chakra-ui/react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { Button } from '~/components/atoms/Button';
+import { ResumeListItem } from '~/components/molecules/ResumeListItem';
+import RadioCardGroup, { RadioOption } from '~/components/organisms/RadioCardGroup/RadioCardGroup';
+import { useGetMyResumes } from '~/queries/resume/useGetMyResumes';
+
+const ResumeSelectTemplate = () => {
+  const { data } = useGetMyResumes();
+  const resumeOptions: RadioOption[] = [];
+  data.map((data) => {
+    const option = {
+      value: data.id.toString(),
+      children: <ResumeListItem data={data} />,
+    };
+    resumeOptions.push(option);
+  });
+  const { register, handleSubmit } = useForm<{ resumeId: string }>();
+  const onSubmit: SubmitHandler<{ resumeId: string }> = (values) => {
+    /**TODO - 이벤트 신청 api 연결 */
+    console.log(values);
+  };
+  return (
+    <>
+      <Text
+        color={'gray.900'}
+        fontWeight={'600'}
+        fontSize={'1.5rem'}
+        mb={'2rem'}
+      >
+        첨삭 신청하기
+      </Text>
+      <Text
+        color={'gray.800'}
+        fontSize={'1.5rem'}
+        fontWeight={'600'}
+        mb={'1rem'}
+      >
+        이력서 선택
+      </Text>
+      <form onSubmit={handleSubmit(onSubmit)}>
+        <Flex
+          direction={'column'}
+          alignItems={'center'}
+          gap={'1.2rem'}
+        >
+          <BorderBox
+            w={'full'}
+            minH={'30rem'}
+            maxH={'90vh'}
+            overflow={'auto'}
+          >
+            <RadioCardGroup
+              options={resumeOptions}
+              formName="resume"
+              defaultValue={data[0].id.toString()}
+              register={{ ...register('resumeId') }}
+              direction="column"
+              overflow={'auto'}
+            />
+          </BorderBox>
+          <HStack alignSelf={'flex-end'}>
+            <Button
+              size={'md'}
+              variant={'cancel'}
+            >
+              취소
+            </Button>
+            <Button size={'md'}>신청하기</Button>
+          </HStack>
+        </Flex>
+      </form>
+    </>
+  );
+};
+
+export default ResumeSelectTemplate;

--- a/src/components/templates/ResumeSelectTemplate/index.ts
+++ b/src/components/templates/ResumeSelectTemplate/index.ts
@@ -1,1 +1,0 @@
-export { default as ResumeSelectTemplate } from './ResumeSelectTemplate';

--- a/src/components/templates/ResumeSelectTemplate/index.ts
+++ b/src/components/templates/ResumeSelectTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as ResumeSelectTemplate } from './ResumeSelectTemplate';

--- a/src/components/templates/SignUpCommonTemplate/index.stories.tsx
+++ b/src/components/templates/SignUpCommonTemplate/index.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { SignUpCommonTemplate } from '.';
+
+const meta = {
+  title: 'Resumeme/Components/SignUpCommonTemplate ',
+  component: SignUpCommonTemplate,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => {
+      const queryClient = new QueryClient();
+
+      return (
+        <QueryClientProvider client={queryClient}>
+          <Story />
+        </QueryClientProvider>
+      );
+    },
+  ],
+} satisfies Meta<typeof SignUpCommonTemplate>;
+
+export default meta;
+
+export const Default = () => {
+  return <SignUpCommonTemplate onNext={() => {}} />;
+};

--- a/src/components/templates/SignUpCommonTemplate/index.stories.tsx
+++ b/src/components/templates/SignUpCommonTemplate/index.stories.tsx
@@ -1,22 +1,10 @@
 import type { Meta } from '@storybook/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SignUpCommonTemplate } from '.';
 
 const meta = {
   title: 'Resumeme/Components/SignUpCommonTemplate ',
   component: SignUpCommonTemplate,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => {
-      const queryClient = new QueryClient();
-
-      return (
-        <QueryClientProvider client={queryClient}>
-          <Story />
-        </QueryClientProvider>
-      );
-    },
-  ],
 } satisfies Meta<typeof SignUpCommonTemplate>;
 
 export default meta;

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -1,4 +1,5 @@
 export const appPaths = {
   signIn: '/sign-in',
   main: '/',
+  resumeCreate: () => '/resume/create',
 };

--- a/src/pages/EventPages/ApplyEventPage/ApplyEventPage.tsx
+++ b/src/pages/EventPages/ApplyEventPage/ApplyEventPage.tsx
@@ -1,6 +1,0 @@
-import { ResumeSelectTemplate } from '~/components/templates/ResumeSelectTemplate';
-const ApplyEventPage = () => {
-  return <ResumeSelectTemplate />;
-};
-
-export default ApplyEventPage;

--- a/src/pages/EventPages/ApplyEventPage/ApplyEventPage.tsx
+++ b/src/pages/EventPages/ApplyEventPage/ApplyEventPage.tsx
@@ -1,5 +1,6 @@
+import { ResumeSelectTemplate } from '~/components/templates/ResumeSelectTemplate';
 const ApplyEventPage = () => {
-  return <></>;
+  return <ResumeSelectTemplate />;
 };
 
 export default ApplyEventPage;

--- a/src/pages/EventPages/ApplyEventPage/index.ts
+++ b/src/pages/EventPages/ApplyEventPage/index.ts
@@ -1,3 +1,0 @@
-import ApplyEventPage from './ApplyEventPage';
-
-export { ApplyEventPage };

--- a/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
@@ -1,28 +1,45 @@
-import { Flex } from '@chakra-ui/react';
+import { Button, Flex, useDisclosure } from '@chakra-ui/react';
+import { Suspense } from 'react';
+import { Spinner } from '~/components/atoms/Spinner';
 import { MentorProfile } from '~/components/molecules/MentorProfile';
+import { Modal } from '~/components/molecules/Modal';
 import { EventDetail } from '~/components/organisms/EventDetail';
+import ResumeSelect from '~/components/organisms/ResumeSelect/ResumeSelect';
 import { useGetEventDetail } from '~/queries/event/details/useGetEventDetail';
 import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const EventDetailPage = () => {
-  //Todo: 이벤트 리스트가 완성되면 "1" 지우기
+  //TODO: 이벤트 리스트가 완성되면 "1" 지우기
   const { data: mentor } = useGetMentorDetail({ mentorId: '1' });
   const { data: event } = useGetEventDetail({ eventId: '1' });
 
+  const { isOpen, onOpen, onClose } = useDisclosure();
   return (
-    <Flex
-      px={'0.56rem'}
-      gap={'2rem'}
-    >
-      <MentorProfile
-        mentor={mentor}
-        event={event}
-      />
-      <EventDetail
-        mentor={mentor}
-        event={event}
-      />
-    </Flex>
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <Suspense fallback={<Spinner />}>
+          <ResumeSelect onCancel={onClose} />
+        </Suspense>
+      </Modal>
+      <Button onClick={onOpen}>temp</Button>
+      <Flex
+        px={'0.56rem'}
+        gap={'2rem'}
+      >
+        <MentorProfile
+          mentor={mentor}
+          event={event}
+          onApply={onOpen}
+        />
+        <EventDetail
+          mentor={mentor}
+          event={event}
+        />
+      </Flex>
+    </>
   );
 };
 

--- a/src/queries/resume/useGetMyResumes.ts
+++ b/src/queries/resume/useGetMyResumes.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { getMyResumes } from '~/api/resume/getMyResumes';
+
+export const useGetMyResumes = () => {
+  return useSuspenseQuery({
+    queryKey: ['getMyResumes'],
+    queryFn: getMyResumes,
+  });
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -1,7 +1,6 @@
 import { createBrowserRouter } from 'react-router-dom';
 import App from '~/App';
 import AdminPage from '~/pages/AdminPage/AdminPage';
-import { ApplyEventPage } from '~/pages/EventPages/ApplyEventPage';
 import { CreateEventPage } from '~/pages/EventPages/CreateEventPage';
 import { EventDetailPage } from '~/pages/EventPages/EventDetailPage';
 import { EventListPage } from '~/pages/EventPages/EventListPage';
@@ -40,7 +39,6 @@ const router = createBrowserRouter([
       { path: 'event/create', element: <CreateEventPage /> },
       { path: 'event/view', element: <EventListPage /> },
       { path: 'event/view/:id', element: <EventDetailPage /> },
-      { path: 'event/view/:id/apply', element: <ApplyEventPage /> },
 
       { path: 'sign-up', element: <SignUpPage /> },
       { path: 'sign-in', element: <SignInPage /> },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -40,7 +40,7 @@ const router = createBrowserRouter([
       { path: 'event/create', element: <CreateEventPage /> },
       { path: 'event/view', element: <EventListPage /> },
       { path: 'event/view/:id', element: <EventDetailPage /> },
-      { path: 'event/apply', element: <ApplyEventPage /> },
+      { path: 'event/view/:id/apply', element: <ApplyEventPage /> },
 
       { path: 'sign-up', element: <SignUpPage /> },
       { path: 'sign-in', element: <SignInPage /> },

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -1,0 +1,5 @@
+export type ResumeListItem = {
+  id: number;
+  title: string;
+  modifiedAt: string;
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<img width="710" alt="스크린샷 2023-11-18 오전 1 29 58" src="https://github.com/resumeme/Frontend/assets/91667853/3ed6d4c2-ef65-4201-bf89-d0e294f817c2">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- ~~이벤트 신청 페이지 UI를 작성했습니다~~ 이력서 리스트 모달로 변경
- 이력서 전체 불러오는 api를 연동했습니다.
- RadioCardGroup을 재사용하다보니 체크된 아이템은 텍스트 color에만 primary.900을 주어 피그마의 디자인에서 Badge의 bgColor에는 primary.900 적용을 못했습니다.
  - 만약 배경 색 적용이 되어야 할 것 같으면 재사용하지 않고 따로 만들어야 할 것 같습니다. 아니면 텍스트에는 컬러 적용이 되니 Badge를 사용하지 않고 텍스트만 두면 텍스트 색은 바뀌긴 할 겁니다! 어떤게 좋을까요? --> Label로 교체

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 이력서가 없을 경우의 처리는 곧 이슈 새로 파서 올리겠습니다.
## 🔎 PR포인트 및 궁금한 점
