### PR TITLE
Gmmq 547 fix: basicInfo GET API 함수에서 phoneNumber 포매팅 추가

### DIFF
--- a/src/api/resume/details/getResumeBasic.ts
+++ b/src/api/resume/details/getResumeBasic.ts
@@ -3,6 +3,7 @@ import { resumeMeAxios } from '~/api/axios';
 import CONSTANTS from '~/constants';
 import { ResumeMeErrorResponse } from '~/types/errorResponse';
 import { getCookie } from '~/utils/cookie';
+import { formatPhoneNumber } from '~/utils/formatPhoneNumber';
 
 export type GetResumeBasic = { resumeId: string };
 
@@ -16,6 +17,11 @@ export const getResumeBasic = async ({ resumeId }: GetResumeBasic) => {
         Authorization: accessToken,
       },
     });
+
+    if (data.ownerInfo && data.ownerInfo.phoneNumber) {
+      data.ownerInfo.phoneNumber = formatPhoneNumber(data.ownerInfo.phoneNumber);
+    }
+
     return data;
   } catch (e) {
     if (isAxiosError<ResumeMeErrorResponse>(e)) {

--- a/src/utils/formatPhoneNumber.ts
+++ b/src/utils/formatPhoneNumber.ts
@@ -1,0 +1,4 @@
+export const formatPhoneNumber = (phoneNumber: string) => {
+  const formattedPhoneNumber = phoneNumber.replace(/(\d{3})(\d{4})(\d{4})/, '$1-$2-$3');
+  return formattedPhoneNumber;
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/b65ddb2c-362f-4a73-9499-9552e33d9ee1)

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- **formatPhoneNumber** 유틸 함수 추가
- basicInfo를 얻어오는 api 함수 getResumeBasic.tsx 에서 phoneNumber 데이터를 포매팅해줍니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- **전화번호 패턴에 따라 포매팅을 다르게 해줘야 하는데, 일단 11자리의 휴대폰 번호만 포매팅하게 되어 있습니다.**

## 🔎 PR포인트 및 궁금한 점
