### PR TITLE
fix: 회원가입 -> 로그인 페이지 리다이렉션 조건 추가

### DIFF
--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -32,7 +32,14 @@ const SignUpPage = () => {
     }
   };
   useEffect(() => {
-    if (user && !cacheKey && step === 'COMMON') {
+    if (user) {
+      toast({
+        description: '이미 가입된 회원입니다.',
+      });
+      navigate(appPaths.main);
+      return;
+    }
+    if (!cacheKey && step === 'COMMON') {
       toast({
         description: '소셜 로그인을 먼저 해주세요.',
       });

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -14,12 +14,14 @@ import { SignUpRole, SignUpCommon } from '~/types/signUp';
 export type Step = 'COMMON' | SignUpRole | 'MENTOR_COMPLETE' | 'MENTEE_COMPLETE';
 
 const SignUpPage = () => {
+  const { mutate: signUpMutate } = usePostOAuthSignUp();
   const [step, setStep] = useState<Step>('COMMON');
   const [commonData, setCommonData] = useState<SignUpCommon>();
-  const { mutate: signUpMutate } = usePostOAuthSignUp();
   const cacheKey = useCacheKeyStore((state) => state.cacheKey);
   const resetCacheKey = useCacheKeyStore((state) => state.resetCacheKey);
-  const { initialUser } = useUser();
+  const { user, initialUser } = useUser();
+  const toast = useToast();
+  const navigate = useNavigate();
 
   const signUpSuccessCallback = (accessToken: string, refreshToken: string, role: SignUpRole) => {
     const nextStep = role === 'ROLE_MENTEE' ? 'MENTEE_COMPLETE' : 'MENTOR_COMPLETE';
@@ -29,18 +31,15 @@ const SignUpPage = () => {
       initialUser(accessToken, refreshToken);
     }
   };
-
-  const toast = useToast();
-  const navigate = useNavigate();
   useEffect(() => {
-    if (!cacheKey) {
+    if (user && !cacheKey && step === 'COMMON') {
       toast({
         description: '소셜 로그인을 먼저 해주세요.',
       });
       navigate(appPaths.signIn);
       return;
     }
-  }, [cacheKey, navigate, toast]);
+  }, [cacheKey, navigate, toast, user]);
 
   return (
     <>

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -32,7 +32,7 @@ const SignUpPage = () => {
     }
   };
   useEffect(() => {
-    if (user) {
+    if (user && step === 'COMMON') {
       toast({
         description: '이미 가입된 회원입니다.',
       });


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 회원가입 마지막 단계에서 최종 가입을 누르면 가입 완료 화면이 아닌 로그인화면으로 리다이렉트되는 문제를 해결했습니다.
- 기존에 cacheKey없이 sign up 페이지로 접속하면 로그인부터 하도록 useEffect에서 로그인 페이지로 리다이렉션을 시키고 있었는데, 가입 완료하고 나면 cacheKey를 지우고 있어서 마지막 단계에서는 조건을 만족시켜서 리다이렉션을 시키고 있더라고요.
  - 페이지 최초 접속 시 step 상태가 COMMON이라서 step이 COMMON일 때만 리다이렉션이 작동하도록 조건을 추가했습니다.
  - 추가로 이미 로그인한 유저에 대해서는 홈으로 리다이렉트 시키도록 했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
