### PR TITLE
Gmmq 466 feat: 이벤트 신청 api 연결

### DIFF
--- a/src/api/event/postEventApply.ts
+++ b/src/api/event/postEventApply.ts
@@ -1,0 +1,26 @@
+import { resumeMeAxios } from '../axios';
+import CONSTANTS from '~/constants';
+import { getCookie } from '~/utils/cookie';
+
+const postEventApply = async ({
+  resumeId,
+  eventId,
+}: {
+  resumeId: number;
+  eventId: string;
+}): Promise<{ id: number }> => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+  const { data } = await resumeMeAxios.patch(
+    `/v1/events/${eventId}`,
+    { resumeId },
+    {
+      headers: {
+        [CONSTANTS.ACCESS_TOKEN_HEADER]: accessToken,
+      },
+    },
+  );
+
+  return data;
+};
+export default postEventApply;

--- a/src/components/organisms/ResumeSelect/ResumeSelect.tsx
+++ b/src/components/organisms/ResumeSelect/ResumeSelect.tsx
@@ -1,19 +1,22 @@
 import { Flex, HStack, Text, VStack } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
+import { useParams } from 'react-router-dom';
 import RadioCardGroup from '../RadioCardGroup/RadioCardGroup';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Button } from '~/components/atoms/Button';
 import { ResumeListItem } from '~/components/molecules/ResumeListItem';
+import usePostEventApply from '~/queries/event/usePostEventApply';
 import { usePostCreateResume } from '~/queries/resume/create/usePostCreateResume';
 import { useGetMyResumes } from '~/queries/resume/useGetMyResumes';
 
 const ResumeSelect = ({ onCancel }: { onCancel: () => void }) => {
   const { data } = useGetMyResumes();
   const { mutate: postCreateResumeMutate } = usePostCreateResume();
+  const { mutate: postEventApplyMutate } = usePostEventApply();
+  const { id: eventId = '' } = useParams();
   const { register, handleSubmit } = useForm<{ resumeId: string }>();
-  const onSubmit: SubmitHandler<{ resumeId: string }> = (values) => {
-    /**TODO - 이벤트 신청 api 연결 */
-    console.log(values);
+  const onSubmit: SubmitHandler<{ resumeId: string }> = ({ resumeId }) => {
+    postEventApplyMutate({ resumeId: parseInt(resumeId), eventId });
   };
   return (
     <>

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -1,0 +1,4 @@
+export const ERROR_MESSAGES = {
+  NO_REMAIN_SEATS: '이미 모든 신청이 마감되었습니다.',
+  DUPLICATE_APPLICATION_EVENT: '이미 신청한 이력이 있습니다.',
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,6 +1,8 @@
+import { ERROR_MESSAGES } from './errorMessage';
 import { environments } from '~/config/environments';
 
 const CONSTANTS = {
+  ERROR_MESSAGES,
   SIGN_UP_CACHE_KEY: 'sign-up-cache-key',
   CACHE_KEY_HEADER: 'cachekey',
   ACCESS_TOKEN_HEADER: 'authorization',

--- a/src/queries/event/usePostEventApply.ts
+++ b/src/queries/event/usePostEventApply.ts
@@ -1,0 +1,10 @@
+import { useMutation } from '@tanstack/react-query';
+import postEventApply from '~/api/event/postEventApply';
+
+const usePostEventApply = () => {
+  return useMutation({
+    mutationFn: postEventApply,
+  });
+};
+
+export default usePostEventApply;

--- a/src/queries/event/usePostEventApply.ts
+++ b/src/queries/event/usePostEventApply.ts
@@ -2,6 +2,7 @@ import { useToast } from '@chakra-ui/react';
 import { useMutation } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import postEventApply from '~/api/event/postEventApply';
+import CONSTANTS from '~/constants';
 import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
 const usePostEventApply = () => {
@@ -13,11 +14,16 @@ const usePostEventApply = () => {
         description: '이벤트 신청에 성공했습니다.',
       });
     },
+    /**TODO - queryClient에 공통 에러 처리 (onError) 설정해주기 */
     onError: (error) => {
       if (isAxiosError<ResumeMeErrorResponse>(error)) {
-        toast({
-          description: error.response?.data.message,
-        });
+        if (error.response) {
+          const errorCode = error.response.data.code;
+          toast({
+            description: CONSTANTS.ERROR_MESSAGES[errorCode],
+            status: 'error',
+          });
+        }
       }
     },
   });

--- a/src/queries/event/usePostEventApply.ts
+++ b/src/queries/event/usePostEventApply.ts
@@ -1,9 +1,25 @@
+import { useToast } from '@chakra-ui/react';
 import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 import postEventApply from '~/api/event/postEventApply';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
 const usePostEventApply = () => {
+  const toast = useToast();
   return useMutation({
     mutationFn: postEventApply,
+    onSuccess: () => {
+      toast({
+        description: '이벤트 신청에 성공했습니다.',
+      });
+    },
+    onError: (error) => {
+      if (isAxiosError<ResumeMeErrorResponse>(error)) {
+        toast({
+          description: error.response?.data.message,
+        });
+      }
+    },
   });
 };
 

--- a/src/types/errorResponse.ts
+++ b/src/types/errorResponse.ts
@@ -1,4 +1,6 @@
+import CONSTANTS from '~/constants';
+
 export type ResumeMeErrorResponse = {
-  code: string;
+  code: keyof typeof CONSTANTS.ERROR_MESSAGES;
   message: string;
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이벤트 신청 api를 연결했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 에러 메시지를 토스트로 띄우기 위해 useMutation의 onError를 작성했습니다.
- 서버에서 응답하는 에러 코드에 해당하는 메시지를 띄우기 위해 `errorMessages.ts` 상수 파일을 작성했습니다.
- 모든 api에 공통적으로 적용될 사항이라 추후 queryClient 전역 세팅할 때 함께 적용해야 합니다.
## 🔎 PR포인트 및 궁금한 점
