### PR TITLE
Gmmq 570 feat: 첨삭 신청 내역 UI 개발

### DIFF
--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -34,10 +34,10 @@ const FeedbackManagementItem = ({
           color={'gray.500'}
           as={'span'}
           fontSize={'0.75rem'}
+          mb={'1.75rem'}
         >{`${formatDate(modifiedAt)}`}</Text>
       )}
       <Flex
-        mt={'1.75rem'}
         align={'center'}
         gap={'1rem'}
       >

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -1,0 +1,125 @@
+import { Flex, Icon, Input, Spacer, Text } from '@chakra-ui/react';
+import { BiCommentError } from 'react-icons/bi';
+import { MdOutlineArticle } from 'react-icons/md';
+import { useNavigate } from 'react-router-dom';
+import { Button } from '~/components/atoms/Button';
+import { Label } from '~/components/atoms/Label';
+import { FeedbackResume } from '~/types/resume/resumeListItem';
+import { formatDate } from '~/utils/formatDate';
+
+type FeedbackManagementItemProps = {
+  resume: FeedbackResume;
+};
+
+const FeedbackManagementItem = ({
+  resume: { endDate, mentorName, resumeId, startDate, status, title, modifiedAt },
+}: FeedbackManagementItemProps) => {
+  const navigate = useNavigate();
+
+  // TODO api 상태 정해지면 label 컬러 추가
+
+  const handleClick = () => {
+    if (status === 'CLOSE') {
+      navigate(`/resume/${resumeId}`);
+    } else {
+      navigate(`/resume/${resumeId}/edit`);
+    }
+  };
+
+  return (
+    <>
+      {modifiedAt && (
+        <Text
+          color={'gray.500'}
+          as={'span'}
+          fontSize={'0.75rem'}
+        >{`${formatDate(modifiedAt)}`}</Text>
+      )}
+      <Flex
+        mt={'1.75rem'}
+        align={'center'}
+        gap={'1rem'}
+      >
+        <Text
+          fontSize={'1.5rem'}
+          fontWeight={600}
+          color={'gray.800'}
+        >
+          {title}
+        </Text>
+        <Label
+          fontSize={'0.75rem'}
+          p={'0.25rem 0.37rem'}
+          borderRadius={'0.3125rem'}
+        >
+          {status}
+        </Label>
+        <Spacer />
+        <Text
+          fontSize={'0.875rem'}
+          color={'gray.500'}
+        >
+          {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
+            endDate,
+          ).toLocaleDateString()}`}
+        </Text>
+        <Flex
+          align={'center'}
+          gap={'0.5rem'}
+        >
+          <Icon
+            color={'highlight.900'}
+            as={BiCommentError}
+            w={'1.25rem'}
+          />
+          <Text
+            fontSize={'0.875rem'}
+            fontWeight={600}
+          >
+            {mentorName}
+          </Text>
+        </Flex>
+      </Flex>
+      <Flex
+        mt={'1.75rem'}
+        borderRadius={'0.3125rem'}
+        p={'0.75rem 1rem'}
+        bg={'gray.200'}
+        alignItems={'center'}
+        w={'full'}
+        gap={'0.69rem'}
+      >
+        <Icon
+          as={MdOutlineArticle}
+          color={'gray.500'}
+          w={'1.25rem'}
+        />
+        <Input
+          isTruncated
+          flexShrink={1}
+          h={'min-content'}
+          p={0}
+          m={0}
+          border={0}
+          placeholder="이력서에 대한 간단한 메모를 남겨보세요. ex) 12월 25일 제출 전까지 피드백 받기"
+        />
+        <Spacer />
+        {status && (
+          <Button
+            bg={'gray.500'}
+            borderRadius={'0.3125rem'}
+            fontSize={'0.75rem'}
+            p={'0.25rem 1.25rem'}
+            h={'fit-content'}
+            w={'fit-content'}
+            onClick={handleClick}
+          >
+            {status === 'CLOSE' ? '첨삭 내역 확인' : '수정하기'}
+          </Button>
+        )}
+      </Flex>
+    </>
+  );
+};
+
+export default FeedbackManagementItem;

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -4,6 +4,7 @@ import { MdOutlineArticle } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 import { Label } from '~/components/atoms/Label';
+import { appPaths } from '~/config/paths';
 import { FeedbackResume } from '~/types/resume/resumeListItem';
 import { formatDate } from '~/utils/formatDate';
 
@@ -20,9 +21,9 @@ const FeedbackManagementItem = ({
 
   const handleClick = () => {
     if (status === 'CLOSE') {
-      navigate(`/resume/${resumeId}`);
+      navigate(appPaths.resumeDetail(resumeId));
     } else {
-      navigate(`/resume/${resumeId}/edit`);
+      navigate(appPaths.resumeEdit(resumeId));
     }
   };
 

--- a/src/components/organisms/FeedbackManagementItem/index.ts
+++ b/src/components/organisms/FeedbackManagementItem/index.ts
@@ -1,0 +1,3 @@
+import FeedbackManagementItem from './FeedbackManagementItem';
+
+export { FeedbackManagementItem };

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -3,6 +3,7 @@ import { MdOutlineArticle } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
 import { OptionsButton } from '~/components/molecules/OptionsButton';
 import { Option } from '~/components/molecules/OptionsButton/OptionsButton';
+import { appPaths } from '~/config/paths';
 import { useDeleteResume } from '~/queries/resume/delete/useDeleteResume';
 import { MyResume } from '~/types/resume/resumeListItem';
 import { formatDate } from '~/utils/formatDate';
@@ -17,7 +18,7 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
   const { mutate: deleteResume } = useDeleteResume();
 
   const HandleEdit = () => {
-    navigate(`/resume/${id}/edit`);
+    navigate(appPaths.resumeEdit(id));
   };
 
   const HandleDelete = () => {
@@ -44,7 +45,7 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
         <Spacer />
         <OptionsButton options={options} />
       </Flex>
-      <Link to={`/resume/${id}`}>
+      <Link to={appPaths.resumeDetail(id)}>
         <Text
           noOfLines={1}
           mt={'1.5rem'}

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -70,6 +70,8 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
           w={'1.25rem'}
         />
         <Input
+          isTruncated
+          flexShrink={1}
           h={'min-content'}
           p={0}
           m={0}

--- a/src/components/templates/FeedbackManagementTemplate/FeedbackManagementTemplate.tsx
+++ b/src/components/templates/FeedbackManagementTemplate/FeedbackManagementTemplate.tsx
@@ -1,0 +1,74 @@
+import { Flex, Heading, Spacer, Text } from '@chakra-ui/react';
+import { v4 as uuidv4 } from 'uuid';
+import { BorderBox } from '~/components/atoms/BorderBox';
+// import { Button } from '~/components/atoms/Button';
+// import { usePostCreateResume } from '~/queries/resume/create/usePostCreateResume';
+import { FeedbackManagementItem } from '~/components/organisms/FeedbackManagementItem';
+import { FeedbackResume } from '~/types/resume/resumeListItem';
+
+type FeedbackManagementTemplateProps = {
+  resumes: FeedbackResume[];
+};
+
+const FeedbackManagementTemplate = ({ resumes }: FeedbackManagementTemplateProps) => {
+  // const { mutate: createResume } = usePostCreateResume();
+
+  return (
+    <>
+      <Flex
+        mt={'2.5rem'}
+        alignItems={'end'}
+      >
+        <Heading
+          fontSize={'1.25rem'}
+          color={'gray.700'}
+          fontWeight={700}
+        >
+          첨삭 신청 내역
+        </Heading>
+        <Spacer />
+        {/* //TODO - 네비게이션 작업 후 이전 */}
+        {/* <Button
+          p={0}
+          w={'min-content'}
+          h={'min-content'}
+          bg={'gray.200'}
+          size={'md'}
+          color={'gray.500'}
+          onClick={() => createResume()}
+        >
+          새 이력서 작성
+        </Button> */}
+      </Flex>
+      <Flex
+        mt={'1.25rem'}
+        direction={'column'}
+      >
+        <BorderBox
+          borderBottomRadius={0}
+          p={'1.88rem 1.69rem'}
+        >
+          <Text
+            fontSize={'0.85rem'}
+            color={'gray.700'}
+          >
+            {`총 ${resumes.length}건`}
+          </Text>
+        </BorderBox>
+        {resumes.map((resume, index) => (
+          <BorderBox
+            key={uuidv4()}
+            borderTop={0}
+            borderTopRadius={0}
+            borderRadius={index !== resumes.length - 1 ? 0 : undefined}
+            p={'1.75rem 1.5rem'}
+          >
+            <FeedbackManagementItem resume={resume} />
+          </BorderBox>
+        ))}
+      </Flex>
+    </>
+  );
+};
+
+export default FeedbackManagementTemplate;

--- a/src/components/templates/FeedbackManagementTemplate/index.ts
+++ b/src/components/templates/FeedbackManagementTemplate/index.ts
@@ -1,0 +1,3 @@
+import FeedbackManagementTemplate from './FeedbackManagementTemplate';
+
+export { FeedbackManagementTemplate };

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -6,4 +6,6 @@ export const appPaths = {
   viewEvent: '/event/view',
   myPage: (id?: number) => (id ? `/mypage/${id}` : '/'),
   userEditInfo: `/user/edit-info`,
+  resumeDetail: (resumeId: number) => `/resume/${resumeId}`,
+  resumeEdit: (resumeId: number) => `/resume/${resumeId}/edit`,
 };

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,5 +1,6 @@
 import { ERROR_MESSAGES } from './errorMessage';
 import { POSITION } from './position';
+import { RESUME_STATUS } from './status';
 import { environments } from '~/config/environments';
 
 const CONSTANTS = {
@@ -21,6 +22,7 @@ const CONSTANTS = {
   },
   LABEL_MULTI_SELECTABLE: '(여러 개 선택 가능)',
   URL_PATTERN: /^(https?:\/\/)?([\w.-]+\.\w{2,})([\w\W]*)$/,
+  RESUME_STATUS,
 };
 
 export default CONSTANTS;

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,0 +1,10 @@
+// TODO api-docs에 맞는 상태로 변경
+const RESUME_STATUS = {
+  READY: '첨삭 이벤트 오픈 예약',
+  REOPEN: '재 신청 시작',
+  CLOSE: '이벤트 신청 마감',
+  OPEN: '첨삭 이벤트 오픈',
+  FINISH: '이벤트 종료',
+};
+
+export { RESUME_STATUS };

--- a/src/pages/ResumePages/ManagementResumePage/ManagementResumePage.tsx
+++ b/src/pages/ResumePages/ManagementResumePage/ManagementResumePage.tsx
@@ -1,6 +1,8 @@
 import { Box } from '@chakra-ui/react';
 import { ResumeManagementTemplate } from '../../../components/templates/ResumeManagementTemplate';
+import FeedbackManagementTemplate from '~/components/templates/FeedbackManagementTemplate/FeedbackManagementTemplate';
 import { Position } from '~/types/position';
+import { ResumeStatus } from '~/types/resume/status';
 // import { useGetManagementResumes } from '~/queries/resume/details/useGetManagementResumes';
 
 const ManagementResumePage = () => {
@@ -21,6 +23,33 @@ const ManagementResumePage = () => {
     },
   ];
 
+  const feedbackResumes = [
+    {
+      resumeId: 1,
+      status: 'REOPEN' as ResumeStatus,
+      title: '제목',
+      mentorName: '김주승',
+      startDate: '2023-11-18T15:23:01.249679309',
+      endDate: '2023-11-18T16:23:01.249681292',
+    },
+    {
+      resumeId: 1,
+      status: 'OPEN' as ResumeStatus,
+      title: '제목',
+      mentorName: '김주승',
+      startDate: '2023-11-18T15:23:01.249679309',
+      endDate: '2023-11-18T16:23:01.249681292',
+    },
+    {
+      resumeId: 1,
+      status: 'CLOSE' as ResumeStatus,
+      title: '제목',
+      mentorName: '김주승',
+      startDate: '2023-11-18T15:23:01.249679309',
+      endDate: '2023-11-18T16:23:01.249681292',
+    },
+  ];
+
   return (
     <Box
       maxW={'44.25rem'}
@@ -28,6 +57,7 @@ const ManagementResumePage = () => {
       mx={'auto'}
     >
       <ResumeManagementTemplate resumes={resumes} />
+      <FeedbackManagementTemplate resumes={feedbackResumes} />
     </Box>
   );
 };

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -1,3 +1,4 @@
+import { ResumeStatus } from './status';
 import { Position } from '../position';
 
 type ResumeListItem = {
@@ -10,4 +11,15 @@ type MyResume = ResumeListItem & {
   position: Position[];
 };
 
-export type { MyResume, ResumeListItem };
+type FeedbackResume = {
+  resumeId: number;
+  status: ResumeStatus;
+  title: string;
+  mentorName: string;
+  startDate: string;
+  endDate: string;
+  //TODO api 수정 후 ? 없애기
+  modifiedAt?: string;
+};
+
+export type { MyResume, ResumeListItem, FeedbackResume };

--- a/src/types/resume/status.ts
+++ b/src/types/resume/status.ts
@@ -1,0 +1,5 @@
+import { RESUME_STATUS } from './../../constants/status';
+
+type ResumeStatus = keyof typeof RESUME_STATUS;
+
+export type { ResumeStatus };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/3d6ff6f8-d5b7-4858-ac3e-123cb7e09ae0)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
첨삭 신청 내역 탭의 UI 작업을진행했습니다.
변경된 api에 맞는 타입을 생성했습니다.
이력서 상태에 대한 상수를 만들었습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
아직 이력서 상태가 이벤트 상태랑 똑같이 나와있어서(api docs) 문서가 업데이트 되고 추후에 수정해야 할 것 같습니다.

첨삭 신청 내역에 아직 수정날짜가 반영되지 않아서 해당 부분이 보이지 않는 상태입니다. 아래 사진(피그마) 참고
![image](https://github.com/resumeme/Frontend/assets/86753969/be94f307-f480-44f7-a05a-2b83070f6585)


내 이력서 관리 탭에서 path를 해당 pr에서 수정했습니다.

## 🔎 PR포인트 및 궁금한 점
