### PR TITLE
fix: 이벤트 상태 상수 반영

### DIFF
--- a/src/components/molecules/EventGridItem/EventGridItem.tsx
+++ b/src/components/molecules/EventGridItem/EventGridItem.tsx
@@ -88,7 +88,7 @@ const AvatarAndStatus = ({
         />
         <Text color={'gray.900'}>{nickname}</Text>
       </HStack>
-      <Label bg={isActive ? 'primary.900' : 'gray.300'}>{CONSTANTS.EVENT_STATUS[status]}</Label>
+      <Label bg={isActive ? 'primary.900' : 'gray.400'}>{CONSTANTS.EVENT_STATUS[status]}</Label>
     </Flex>
   );
 };

--- a/src/components/molecules/EventGridItem/EventGridItem.tsx
+++ b/src/components/molecules/EventGridItem/EventGridItem.tsx
@@ -5,7 +5,9 @@ import { Avatar } from '~/components/atoms/Avatar';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { appPaths } from '~/config/paths';
+import CONSTANTS from '~/constants';
 import { EventListItem } from '~/types/event/eventList';
+import { EventStatus } from '~/types/eventStatus';
 import { Position } from '~/types/position';
 
 const EventGridItem = ({ event: { info, mentorInfo } }: { event: EventListItem }) => {
@@ -71,11 +73,11 @@ const AvatarAndStatus = ({
   imageUrl,
   nickname,
 }: {
-  status: string;
+  status: EventStatus;
   imageUrl: string;
   nickname: string;
 }) => {
-  const isOpen = status === 'OPEN';
+  const isActive = status === 'OPEN' || status === 'REOPEN';
   return (
     <Flex justifyContent={'space-between'}>
       <HStack>
@@ -86,7 +88,7 @@ const AvatarAndStatus = ({
         />
         <Text color={'gray.900'}>{nickname}</Text>
       </HStack>
-      <Label bg={isOpen ? 'primary.900' : 'gray.300'}>{isOpen ? '모집 중' : '모집 마감'}</Label>
+      <Label bg={isActive ? 'primary.900' : 'gray.300'}>{CONSTANTS.EVENT_STATUS[status]}</Label>
     </Flex>
   );
 };

--- a/src/components/organisms/EventDetail/EventTitle.tsx
+++ b/src/components/organisms/EventDetail/EventTitle.tsx
@@ -1,13 +1,15 @@
 import { Flex, Heading } from '@chakra-ui/react';
 import { Label } from '~/components/atoms/Label';
+import CONSTANTS from '~/constants';
+import { EventStatus } from '~/types/eventStatus';
 
 type EventTitle = {
   title: string;
-  //TODO - 상태 수정
-  eventStatus: string;
+  eventStatus: EventStatus;
 };
 
 const EventTitle = ({ title, eventStatus }: EventTitle) => {
+  const isActive = eventStatus === 'OPEN' || eventStatus === 'REOPEN';
   return (
     <Flex
       p={'1rem'}
@@ -17,10 +19,10 @@ const EventTitle = ({ title, eventStatus }: EventTitle) => {
       <Heading fontSize={'1.5rem'}>{title}</Heading>
       <Label
         fontSize={'0.875rem'}
-        bg={eventStatus === 'OPEN' ? 'primary.900' : 'gray.500'}
+        bg={isActive ? 'primary.900' : 'gray.400'}
         textAlign={'center'}
       >
-        {eventStatus === 'OPEN' ? '모집 중' : '모집 마감'}
+        {CONSTANTS.EVENT_STATUS[eventStatus]}
       </Label>
     </Flex>
   );


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- `이벤트 리스트 페이지`, `이벤트 상세 페이지`의 이벤트 아이템에 뜨는 이벤트 상세 뱃지의 내용이 상수를 활용하도록 수정했습니다.
- CONSTANTS.EVENT_STATUS에 있는 맵핑 데이터를 활용해 이벤트 상태를 띄웁니다.
- OPEN, REOPEN 상태는 primary.900, 그 외는 gray.400 색상을 적용했습니다.
- Label에 이벤트 상태도 추가하면 좋을 것 같습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
