### PR TITLE
Gmmq 598 refactor: ConfirmModal EditDeleteOptionsButton으로 이동

### DIFF
--- a/src/components/molecules/OptionsButton/EditDeleteOptionsButton.tsx
+++ b/src/components/molecules/OptionsButton/EditDeleteOptionsButton.tsx
@@ -1,5 +1,7 @@
+import { useDisclosure } from '@chakra-ui/react';
 import OptionsButton from './OptionsButton';
 import { Option } from './OptionsButton';
+import { ConfirmModal } from '../ConfirmModal';
 
 const EditDeleteOptionsButton = ({
   onEdit,
@@ -10,9 +12,20 @@ const EditDeleteOptionsButton = ({
 }) => {
   const options: Option[] = [
     { text: '수정하기', onClick: onEdit },
-    { text: '삭제하기', onClick: onDelete },
+    { text: '삭제하기', onClick: () => onOpen() },
   ];
-  return <OptionsButton options={options} />;
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  return (
+    <>
+      <ConfirmModal
+        isOpen={isOpen}
+        onClose={onClose}
+        message="정말로 삭제하시겠습니까?"
+        proceed={onDelete}
+      />
+      <OptionsButton options={options} />
+    </>
+  );
 };
 
 export default EditDeleteOptionsButton;

--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -1,9 +1,8 @@
-import { Flex, Text, Heading, Link, Icon, useDisclosure } from '@chakra-ui/react';
+import { Flex, Text, Heading, Link, Icon } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -17,12 +16,10 @@ const ActivityDetails = ({
 }: DetailsComponentProps<Activity>) => {
   const { id: resumeId = '' } = useParams();
   const blockId = componentId as string;
-  const { mutate: deleteLanguageMutate } = useOptimisticDeleteCategory<Activity>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Activity>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.activity(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -96,18 +93,10 @@ const ActivityDetails = ({
         </Flex>
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteLanguageMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteMutate({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeDetails/AwardDetails.tsx
+++ b/src/components/organisms/ResumeDetails/AwardDetails.tsx
@@ -1,9 +1,8 @@
-import { Flex, Text, Heading, Icon, Link, useDisclosure } from '@chakra-ui/react';
+import { Flex, Text, Heading, Icon, Link } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -17,12 +16,10 @@ const AwardDetails = ({
 }: DetailsComponentProps<Award>) => {
   const { id: resumeId = '' } = useParams();
   const blockId = componentId as string;
-  const { mutate: deleteLanguageMutate } = useOptimisticDeleteCategory<Award>({
+  const { mutate: deleteAward } = useOptimisticDeleteCategory<Award>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.award(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -83,18 +80,10 @@ const AwardDetails = ({
         </Flex>
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteLanguageMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteAward({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -1,9 +1,8 @@
-import { Box, Text, Flex, Heading, useDisclosure } from '@chakra-ui/react';
+import { Box, Text, Flex, Heading } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { v4 as uuidv4 } from 'uuid';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -27,12 +26,10 @@ const CareerDetails = ({
 }: DetailsComponentProps<Career>) => {
   const { id: resumeId = '' } = useParams();
   const blockId = componentId as string;
-  const { mutate: deleteCareerMutate } = useOptimisticDeleteCategory<Career>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Career>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.career(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -141,18 +138,10 @@ const CareerDetails = ({
         ))}
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteCareerMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteMutate({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -1,8 +1,7 @@
-import { Flex, Text, Divider, Heading, useDisclosure } from '@chakra-ui/react';
+import { Flex, Text, Divider, Heading } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -22,12 +21,10 @@ const LanguageDetails = ({
 }: DetailsComponentProps<Language>) => {
   const { id: resumeId = '' } = useParams();
   const blockId = componentId as string;
-  const { mutate: deleteLanguageMutate } = useOptimisticDeleteCategory<Language>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Language>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.language(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -71,7 +68,7 @@ const LanguageDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteCareerMutate({ resumeId, blockId })}
+          onDelete={() => deleteMutate({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -69,18 +69,10 @@ const LanguageDetails = ({
         </Flex>
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteLanguageMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteCareerMutate({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -1,9 +1,8 @@
-import { Flex, Heading, Icon, Link, Text, useDisclosure } from '@chakra-ui/react';
+import { Flex, Heading, Icon, Link, Text } from '@chakra-ui/react';
 import { HiLink } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -26,12 +25,10 @@ const ProjectDetails = ({
 }: DetailsComponentProps<Project>) => {
   const { id: resumeId } = useParams() as { id: string };
   const blockId = componentId as string;
-  const { mutate: deleteProjectMutate } = useOptimisticDeleteCategory<Project>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Project>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.project(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -134,18 +131,10 @@ const ProjectDetails = ({
         </Flex>
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteProjectMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteMutate({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeDetails/TrainingDetails.tsx
+++ b/src/components/organisms/ResumeDetails/TrainingDetails.tsx
@@ -1,8 +1,7 @@
-import { Divider, Flex, Heading, Text, useDisclosure } from '@chakra-ui/react';
+import { Divider, Flex, Heading, Text } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { deleteResumeCategoryBlock } from '~/api/resume/delete/deleteResumeCategoryBlock';
 import { Label } from '~/components/atoms/Label';
-import { ConfirmModal } from '~/components/molecules/ConfirmModal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { categoryKeys } from '~/queries/resume/categoryKeys.const';
 import { useOptimisticDeleteCategory } from '~/queries/resume/useOptimisticDeleteCategory';
@@ -26,12 +25,10 @@ const TraningDetails = ({
 }: DetailsComponentProps<Training>) => {
   const { id: resumeId } = useParams() as { id: string };
   const blockId = componentId as string;
-  const { mutate: deleteTrainingMutate } = useOptimisticDeleteCategory<Training>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Training>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.training(resumeId),
   });
-
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   return (
     <Flex>
@@ -136,18 +133,10 @@ const TraningDetails = ({
         </Flex>
       </Flex>
       {isCurrentUser && (
-        <>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={() => deleteTrainingMutate({ resumeId, blockId })}
-          />
-          <EditDeleteOptionsButton
-            onEdit={onEdit}
-            onDelete={() => onOpen()}
-          />
-        </>
+        <EditDeleteOptionsButton
+          onEdit={onEdit}
+          onDelete={() => deleteMutate({ resumeId, blockId })}
+        />
       )}
     </Flex>
   );

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -1,8 +1,7 @@
 import { Flex, Icon, Input, Spacer, Text } from '@chakra-ui/react';
 import { MdOutlineArticle } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
-import { OptionsButton } from '~/components/molecules/OptionsButton';
-import { Option } from '~/components/molecules/OptionsButton/OptionsButton';
+import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { appPaths } from '~/config/paths';
 import { useDeleteResume } from '~/queries/resume/delete/useDeleteResume';
 import { MyResume } from '~/types/resume/resumeListItem';
@@ -22,15 +21,8 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
   };
 
   const HandleDelete = () => {
-    // deleteResume({ resumeId: String(id) });
-    deleteResume({ resumeId: '752' });
+    deleteResume({ resumeId: String(id) });
   };
-
-  const options: Option[] = [
-    { text: '수정하기', onClick: HandleEdit },
-    //공개하기?추가예정
-    { text: '삭제하기', onClick: HandleDelete },
-  ];
 
   return (
     <>
@@ -43,7 +35,10 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
           >{`${formatDate(modifiedAt)} 수정`}</Text>
         )}
         <Spacer />
-        <OptionsButton options={options} />
+        <EditDeleteOptionsButton
+          onDelete={HandleDelete}
+          onEdit={HandleEdit}
+        />
       </Flex>
       <Link to={appPaths.resumeDetail(id)}>
         <Text


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 기존 ConfirmModal은 EditDeleteOptionsButton과 짝꿍으로 따라다녔는데, 아예 EditDeleteOptionsButton 내부로 옮겼습니다.
- 따라서 사용하는 곳에서 ConfirmModal, useDisclosure를 불러올 필요 없이 EditDeleteOptionsButton만 작성하고 onEdit, onDelete를 전달하면 삭제하기를 눌렀을 때 알아서 컨펌 모달을 먼저 띄웁니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
