### PR TITLE
Gmmq 568 feat: 페이지네이션 컴포넌트, 이벤트 그리드 페이지에 적용

### DIFF
--- a/src/api/event/getEventList.ts
+++ b/src/api/event/getEventList.ts
@@ -1,12 +1,13 @@
 import { resumeMeAxios } from '../axios';
 import CONSTANTS from '~/constants';
 import { EventList } from '~/types/event/eventList';
+import { Pagination } from '~/types/pagination';
 import { getCookie } from '~/utils/cookie';
 
-export const getEventList = async (): Promise<EventList> => {
+export const getEventList = async ({ page, size }: Pagination): Promise<EventList> => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
 
-  const { data } = await resumeMeAxios.get(`/v1/events`, {
+  const { data } = await resumeMeAxios.get(`/v1/events?page=${page}&size=${size}`, {
     headers: {
       Authorization: accessToken,
     },

--- a/src/api/event/getEventList.ts
+++ b/src/api/event/getEventList.ts
@@ -7,7 +7,7 @@ import { getCookie } from '~/utils/cookie';
 export const getEventList = async ({ page, size }: Pagination): Promise<EventList> => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
 
-  const { data } = await resumeMeAxios.get(`/v1/events?page=${page}&size=${size}`, {
+  const { data } = await resumeMeAxios.get(`/v1/events?page=${page - 1}&size=${size}`, {
     headers: {
       Authorization: accessToken,
     },

--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -17,9 +17,14 @@ type PaginationProps = {
 const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
   const totalPageCount = Math.ceil(total / size);
   return (
-    <Flex>
+    <Flex
+      w={'full'}
+      justifyContent={'center'}
+      mt={'10rem'}
+    >
       <IconButton
         w={'auto'}
+        bg={'none'}
         icon={<ChevronLeftIcon />}
         aria-label="이전 페이지로 이동"
         isDisabled={page === 1}
@@ -50,6 +55,7 @@ const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
         })}
       <IconButton
         w={'auto'}
+        bg={'none'}
         icon={<ChevronRightIcon />}
         aria-label="다음 페이지로 이동"
         isDisabled={page === totalPageCount}

--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -7,7 +7,7 @@ import { Flex, IconButton, Button as ChakraButton, Text } from '@chakra-ui/react
  * page: 현재 페이지 state
  * setPage: 현재 페이지 setState 함수
  */
-export type PaginationProps = {
+type PaginationProps = {
   total: number;
   limit: number;
   page: number;

--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -1,0 +1,62 @@
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { Flex, IconButton, Button as ChakraButton, Text } from '@chakra-ui/react';
+
+/**
+ * total: 전체 아이템 개수
+ * limit: 한 페이지 당 보여줄 아이템 개수
+ * page: 현재 페이지 state
+ * setPage: 현재 페이지 setState 함수
+ */
+export type PaginationProps = {
+  total: number;
+  limit: number;
+  page: number;
+  setPage: React.Dispatch<React.SetStateAction<number>>;
+};
+
+const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
+  const totalPageCount = Math.ceil(total / limit);
+  return (
+    <Flex>
+      <IconButton
+        w={'auto'}
+        icon={<ChevronLeftIcon />}
+        aria-label="이전 페이지로 이동"
+        isDisabled={page === 1}
+        onClick={() => setPage(page - 1)}
+      />
+      {Array(totalPageCount)
+        .fill(null)
+        .map((_, i) => {
+          const isCurrentPage = page === i + 1;
+          return (
+            <ChakraButton
+              key={i + 1}
+              onClick={() => setPage(i + 1)}
+              bg={isCurrentPage ? 'primary.900' : 'none'}
+              _hover={{
+                bg: isCurrentPage ? 'primary.900' : 'primary.100',
+              }}
+              w={'auto'}
+            >
+              <Text
+                fontSize={'1.2rem'}
+                color={isCurrentPage ? 'gray.100' : 'gray. 700'}
+              >
+                {i + 1}
+              </Text>
+            </ChakraButton>
+          );
+        })}
+      <IconButton
+        w={'auto'}
+        icon={<ChevronRightIcon />}
+        aria-label="다음 페이지로 이동"
+        isDisabled={page === totalPageCount}
+        onClick={() => setPage(page + 1)}
+      />
+    </Flex>
+  );
+};
+
+export default Pagination;

--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -3,19 +3,19 @@ import { Flex, IconButton, Button as ChakraButton, Text } from '@chakra-ui/react
 
 /**
  * total: 전체 아이템 개수
- * limit: 한 페이지 당 보여줄 아이템 개수
+ * size: 한 페이지 당 보여줄 아이템 개수
  * page: 현재 페이지 state
  * setPage: 현재 페이지 setState 함수
  */
 type PaginationProps = {
   total: number;
-  limit: number;
+  size: number;
   page: number;
   setPage: React.Dispatch<React.SetStateAction<number>>;
 };
 
-const Pagination = ({ total, limit, page, setPage }: PaginationProps) => {
-  const totalPageCount = Math.ceil(total / limit);
+const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
+  const totalPageCount = Math.ceil(total / size);
   return (
     <Flex>
       <IconButton

--- a/src/components/molecules/Pagination/index.stories.tsx
+++ b/src/components/molecules/Pagination/index.stories.tsx
@@ -12,10 +12,10 @@ export default meta;
 
 type Story = StoryObj<{
   total: number;
-  limit: number;
+  size: number;
 }>;
 
-export const Default: Story = (args: { total: number; limit: number }) => {
+export const Default: Story = (args: { total: number; size: number }) => {
   const [page, setPage] = useState(1);
   return (
     <Pagination
@@ -28,5 +28,5 @@ export const Default: Story = (args: { total: number; limit: number }) => {
 
 Default.args = {
   total: 100,
-  limit: 10,
+  size: 10,
 };

--- a/src/components/molecules/Pagination/index.stories.tsx
+++ b/src/components/molecules/Pagination/index.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { useState } from 'react';
-import Pagination, { PaginationProps } from './Pagination';
+import Pagination from './Pagination';
 
 const meta = {
   title: 'Resumeme/Components/Pagination',
@@ -10,7 +10,10 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj<PaginationProps>;
+type Story = StoryObj<{
+  total: number;
+  limit: number;
+}>;
 
 export const Default: Story = (args: { total: number; limit: number }) => {
   const [page, setPage] = useState(1);

--- a/src/components/molecules/Pagination/index.stories.tsx
+++ b/src/components/molecules/Pagination/index.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState } from 'react';
+import Pagination, { PaginationProps } from './Pagination';
+
+const meta = {
+  title: 'Resumeme/Components/Pagination',
+  component: Pagination,
+  tags: ['autodocs'],
+} satisfies Meta<typeof Pagination>;
+
+export default meta;
+
+type Story = StoryObj<PaginationProps>;
+
+export const Default: Story = (args: { total: number; limit: number }) => {
+  const [page, setPage] = useState(1);
+  return (
+    <Pagination
+      {...args}
+      page={page}
+      setPage={setPage}
+    />
+  );
+};
+
+Default.args = {
+  total: 100,
+  limit: 10,
+};

--- a/src/components/molecules/Pagination/index.ts
+++ b/src/components/molecules/Pagination/index.ts
@@ -1,0 +1,1 @@
+export { default as Pagination } from './Pagination';

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -18,13 +18,19 @@ const EventGridTemplate = () => {
       >
         진행 중인 첨삭 이벤트
       </Text>
-      <EventGrid events={data.events} />
-      <Pagination
-        size={size}
-        page={page}
-        setPage={setPage}
-        total={data.pageData.totalElements}
-      />
+      {data.events.length ? (
+        <>
+          <EventGrid events={data.events} />
+          <Pagination
+            size={size}
+            page={page}
+            setPage={setPage}
+            total={data.pageData.totalElements}
+          />
+        </>
+      ) : (
+        <Text>진행 중인 이벤트가 없어요. ૮ ´• ﻌ ´• ა</Text>
+      )}
     </>
   );
 };

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -22,7 +22,7 @@ const EventGridTemplate = () => {
         size={size}
         page={page}
         setPage={setPage}
-        total={data.pageData.pageData.totalElements}
+        total={data.pageData.totalElements}
       />
     </>
   );

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -1,9 +1,13 @@
 import { Text } from '@chakra-ui/react';
+import { useState } from 'react';
+import { Pagination } from '~/components/molecules/Pagination';
 import { EventGrid } from '~/components/organisms/EventGrid';
 import { useGetEventList } from '~/queries/event/useGetEventList';
 
 const EventGridTemplate = () => {
-  const { data } = useGetEventList();
+  const [page, setPage] = useState(1);
+  const size = 10;
+  const { data } = useGetEventList({ page, size });
   return (
     <>
       <Text
@@ -14,6 +18,12 @@ const EventGridTemplate = () => {
         진행 중인 첨삭 이벤트
       </Text>
       <EventGrid events={data.events} />
+      <Pagination
+        size={size}
+        page={page}
+        setPage={setPage}
+        total={data.pageData.pageData.totalElements}
+      />
     </>
   );
 };

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -6,8 +6,9 @@ import { useGetEventList } from '~/queries/event/useGetEventList';
 
 const EventGridTemplate = () => {
   const [page, setPage] = useState(1);
-  const size = 10;
+  const size = 6;
   const { data } = useGetEventList({ page, size });
+
   return (
     <>
       <Text

--- a/src/queries/event/eventKeys.const.ts
+++ b/src/queries/event/eventKeys.const.ts
@@ -1,0 +1,9 @@
+export const eventKeys = {
+  all: ['events'] as const,
+  getPaginatedEvents: (page: number, size: number) => [
+    ...eventKeys.all,
+    'getPaginatedEvents',
+    { page },
+    { size },
+  ],
+};

--- a/src/queries/event/useGetEventList.ts
+++ b/src/queries/event/useGetEventList.ts
@@ -1,9 +1,10 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getEventList } from '~/api/event/getEventList';
+import { Pagination } from '~/types/pagination';
 
-export const useGetEventList = () => {
+export const useGetEventList = ({ page, size }: Pagination) => {
   return useSuspenseQuery({
     queryKey: ['getEventList'],
-    queryFn: getEventList,
+    queryFn: () => getEventList({ page, size }),
   });
 };

--- a/src/queries/event/useGetEventList.ts
+++ b/src/queries/event/useGetEventList.ts
@@ -1,10 +1,11 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { getEventList } from '~/api/event/getEventList';
+import { eventKeys } from '~/queries/event/eventKeys.const';
 import { Pagination } from '~/types/pagination';
 
 export const useGetEventList = ({ page, size }: Pagination) => {
   return useSuspenseQuery({
-    queryKey: ['getEventList'],
+    queryKey: eventKeys.getPaginatedEvents(page, size),
     queryFn: () => getEventList({ page, size }),
   });
 };

--- a/src/types/pageData.ts
+++ b/src/types/pageData.ts
@@ -1,15 +1,13 @@
 export type PageData = {
-  pageData: {
-    first: boolean;
-    last: boolean;
-    number: number;
-    size: number;
-    sort: {
-      empty: boolean;
-      sorted: boolean;
-      unsorted: boolean;
-    };
-    totalPages: number;
-    totalElements: number;
+  first: boolean;
+  last: boolean;
+  number: number;
+  size: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
   };
+  totalPages: number;
+  totalElements: number;
 };

--- a/src/types/pagination.ts
+++ b/src/types/pagination.ts
@@ -1,0 +1,4 @@
+export type Pagination = {
+  page: number;
+  size: number;
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="918" alt="스크린샷 2023-11-21 오후 12 37 13" src="https://github.com/resumeme/Frontend/assets/91667853/3e55d1cf-bb13-4d9a-80a7-c97fcd111318">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 페이지네이션 컴포넌트를 작성했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
### Pagination Props
```typescript
/**
 * total: 전체 아이템 개수 - 서버가 주는 pageData의 `totalElements` 사용
 * size: 한 페이지 당 보여줄 아이템 개수 - 사용하는 곳에서 지정
 * page: 현재 페이지 state - useState의 state, 사용하는 곳에서 생성해 전달 (1부터 시작!)
 * setPage: 현재 페이지 setState 함수
 */
type PaginationProps = {
  total: number;
  size: number;
  page: number;
  setPage: React.Dispatch<React.SetStateAction<number>>;
};
```
**page는 1부터 시작합니다. 
다만 서버에 요청을 보낼 때의 page는 0부터 시작하기 때문에 api 함수 내에서 쿼리 파라미터에 -1을 해서 보내고 있습니다.
Pagination 컴포넌트 사용 예시는 `EventGridTemplate.tsx`를 참고하시면 됩니다.**
## 🔎 PR포인트 및 궁금한 점
현재 페이지인 경우 배경 색을 primary.900으로 해놨는데, 색상 괜찮은가요? 좀 더 연한 게 나을지.. 이대로 괜찮은지.. 봐주세요!
⬇️ primary.700
<img width="853" alt="스크린샷 2023-11-21 오후 12 42 54" src="https://github.com/resumeme/Frontend/assets/91667853/2202a1f7-9335-43bf-b068-e50583fa51d0">
