### PR TITLE
hotfix: duties 빈배열로 보내기

### DIFF
--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -73,6 +73,7 @@ const CareerForm = ({
       return;
     }
     body.skills = skills;
+    body.duties = body.duties || [];
     if (!isEdit) {
       postCareerMutate({ resumeId, body });
     } else if (isEdit && blockId) {


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 업무경험 저장하며 주요 업무를 작성하지 않은 경우
  - post 요청할 때 첫 번째 요청에서는 duties가 빈 배열로 가는데,
  - 두 번째 요청부터는 duties가 body에 포함되지 않고 있었음
 ➡️ 서버에서 null 체크를 제대로 못하는 문제가 있어 주요 업무를 작성하지 않으면 무조건 빈 배열이 가도록 수정했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
