### PR TITLE
Gmmq 639 fix: 이벤트 상세 페이지 링크 연결, 메모 - 이력서 제목으로 변경

### DIFF
--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -12,7 +12,7 @@ type FeedbackManagementItemProps = {
 };
 
 const FeedbackManagementItem = ({
-  resume: { endDate, mentorName, resumeId, startDate, status, title, resumeTitle, eventId },
+  resume: { endDate, mentorName, resumeId, startDate, status, title, eventId },
 }: FeedbackManagementItemProps) => {
   const navigate = useNavigate();
 
@@ -88,7 +88,8 @@ const FeedbackManagementItem = ({
           color={'gray.500'}
           w={'1.25rem'}
         />
-        {resumeTitle && <Text>{resumeTitle}</Text>}
+        {/*TODO 주석해제 {resumeTitle && <Text>{resumeTitle}</Text>} */}
+        <Text>내 이력서</Text>
         <Spacer />
         {status && (
           <Button

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -1,7 +1,7 @@
-import { Flex, Icon, Input, Spacer, Text } from '@chakra-ui/react';
+import { Flex, Icon, Spacer, Text } from '@chakra-ui/react';
 import { BiCommentError } from 'react-icons/bi';
 import { MdOutlineArticle } from 'react-icons/md';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 import { Label } from '~/components/atoms/Label';
 import { appPaths } from '~/config/paths';
@@ -12,7 +12,7 @@ type FeedbackManagementItemProps = {
 };
 
 const FeedbackManagementItem = ({
-  resume: { endDate, mentorName, resumeId, startDate, status, title, eventId },
+  resume: { endDate, mentorName, resumeId, startDate, status, title, resumeTitle, eventId },
 }: FeedbackManagementItemProps) => {
   const navigate = useNavigate();
 
@@ -32,13 +32,15 @@ const FeedbackManagementItem = ({
         align={'center'}
         gap={'1rem'}
       >
-        <Text
-          fontSize={'1.5rem'}
-          fontWeight={600}
-          color={'gray.800'}
-        >
-          {title}
-        </Text>
+        <Link to={appPaths.eventDetail(eventId)}>
+          <Text
+            fontSize={'1.5rem'}
+            fontWeight={600}
+            color={'gray.800'}
+          >
+            {title}
+          </Text>
+        </Link>
         <Label
           fontSize={'0.75rem'}
           p={'0.25rem 0.37rem'}
@@ -86,15 +88,7 @@ const FeedbackManagementItem = ({
           color={'gray.500'}
           w={'1.25rem'}
         />
-        <Input
-          isTruncated
-          flexShrink={1}
-          h={'min-content'}
-          p={0}
-          m={0}
-          border={0}
-          placeholder="이력서에 대한 간단한 메모를 남겨보세요. ex) 12월 25일 제출 전까지 피드백 받기"
-        />
+        {resumeTitle && <Text>{resumeTitle}</Text>}
         <Spacer />
         {status && (
           <Button

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -12,6 +12,8 @@ type MyResume = ResumeListItem & {
 };
 
 type FeedbackResume = {
+  //TODO - api 수정 후 변경 - ?제거, title-eventTItle로 변경
+  resumeTitle?: string;
   eventId: number;
   resumeId: number;
   status: ResumeStatus;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
첨삭 관리 페이지에서 이벤트 제목을 클릭하면 이벤트 상세 페이지로 합니다.
메모 부분을 이력서 제목으로 변경했습니다.
추후에 api response가 수정되면 마저 고치겠습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
