### PR TITLE
Gmmq 613 feat: 이력서 첨삭 페이지 - 전체 기능 완성 (完)

### DIFF
--- a/src/api/resume/feedback/deleteFeedbackComment.ts
+++ b/src/api/resume/feedback/deleteFeedbackComment.ts
@@ -1,0 +1,27 @@
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { getCookie } from '~/utils/cookie';
+
+type DeleteFeedbackComment = {
+  eventId: string;
+  resumeId: string;
+  commentId: number;
+};
+
+export const deleteFeedbackComment = async ({
+  eventId,
+  resumeId,
+  commentId,
+}: DeleteFeedbackComment) => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+  const { data } = await resumeMeAxios.patch(
+    `/v1/events/${eventId}/resumes/${resumeId}/comments/${commentId}`,
+    {
+      headers: {
+        Authorization: accessToken,
+      },
+    },
+  );
+  return data;
+};

--- a/src/api/resume/feedback/patchFeedbackComment.ts
+++ b/src/api/resume/feedback/patchFeedbackComment.ts
@@ -1,0 +1,31 @@
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { FeedbackComment } from '~/types/event/feedback';
+import { getCookie } from '~/utils/cookie';
+
+type PatchFeedbackComment = {
+  eventId: string;
+  resumeId: string;
+  commentId: number;
+  body: Pick<FeedbackComment, 'content'>;
+};
+
+export const patchFeedbackComment = async ({
+  eventId,
+  resumeId,
+  commentId,
+  body,
+}: PatchFeedbackComment) => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+  const { data } = await resumeMeAxios.patch(
+    `/v1/events/${eventId}/resumes/${resumeId}/comments/${commentId}`,
+    body,
+    {
+      headers: {
+        Authorization: accessToken,
+      },
+    },
+  );
+  return data;
+};

--- a/src/components/molecules/ConfirmModal/ConfirmModal.tsx
+++ b/src/components/molecules/ConfirmModal/ConfirmModal.tsx
@@ -22,6 +22,7 @@ const ConfirmModal = ({ message, isOpen, onClose, proceed }: ConfirmModalProps) 
       isOpen={isOpen}
       leastDestructiveRef={cancelRef}
       onClose={onClose}
+      isCentered
     >
       <AlertDialogOverlay>
         <AlertDialogContent py={4}>

--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -1,7 +1,13 @@
-import { Box, Flex, Text, Divider, Icon, Tooltip } from '@chakra-ui/react';
+import { Box, Flex, Text, Divider, Icon, Tooltip, useDisclosure } from '@chakra-ui/react';
 import MDEditor from '@uiw/react-md-editor';
+import { useState } from 'react';
 import { HiPencilAlt, HiTrash } from 'react-icons/hi';
+import { useParams } from 'react-router-dom';
+import { ConfirmModal } from '../ConfirmModal';
+import { FeedbackInput } from '../FeedbackInput';
 import { BorderBox } from '~/components/atoms/BorderBox';
+import useDeleteFeedbackComment from '~/queries/event/useDeleteFeedbackComment';
+import usePatchFeedbackComment from '~/queries/event/usePatchFeedbackComment';
 import { formatKoreanDateWithoutSeconds } from '~/utils/formatDate';
 import '@uiw/react-markdown-preview/markdown.css';
 
@@ -9,7 +15,6 @@ type FeedbackViewProps = {
   content?: string;
   lastModifiedAt?: string;
   commentId?: number;
-  componentId?: number;
   isAuthorizedMentor?: boolean;
 };
 
@@ -24,112 +29,157 @@ const FeedbackView = ({
 - **반갑습니다.**`,
   lastModifiedAt = '2023-11-15 17:17:09',
   commentId,
-  componentId,
   isAuthorizedMentor = false,
 }: FeedbackViewProps) => {
-  const handleRemove = () => {
-    /* TODO 코멘트 삭제 API */
-    alert(`commentId: ${commentId}`);
+  const [isEdit, setIsEdit] = useState<boolean>(false);
+  const [value, setValue] = useState<string | undefined>(content);
+  const { resumeId = '', eventId = '' } = useParams();
+  const { mutate: patchCommentMutate } = usePatchFeedbackComment(resumeId, eventId);
+  const { mutate: deleteCommentMutate } = useDeleteFeedbackComment(resumeId, eventId);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const isEditToggle = () => {
+    setIsEdit(!isEdit);
+  };
+
+  const handleValueChange = (newValue: string | undefined) => {
+    if (newValue) {
+      setValue(newValue);
+    }
+  };
+
+  const handleModalOpen = () => {
+    onOpen();
   };
 
   const handleEdit = () => {
-    /* TODO 코멘트 수정 함수
-      - componentId, commentId로 FeedbackInput 컴포넌트 보여줌
-      - FeedbackView 컴포넌트 숨김
-    */
-    alert(`componentId: ${componentId}`);
+    if (value && commentId) {
+      const body = {
+        content: value,
+      };
+      patchCommentMutate(
+        { resumeId, eventId, commentId, body },
+        {
+          onSuccess: () => {
+            setValue('');
+            isEditToggle();
+          },
+        },
+      );
+    }
+  };
+
+  const handleRemove = () => {
+    if (resumeId && eventId && commentId) {
+      deleteCommentMutate({ resumeId, eventId, commentId });
+    }
   };
 
   const fomattedDate = formatKoreanDateWithoutSeconds(lastModifiedAt);
 
   return (
-    <BorderBox p={0}>
-      <Flex
-        justify={'space-between'}
-        borderWidth="1px"
-        borderTopRadius="1.06rem"
-        borderColor={'transparent'}
-        bg={'gray.200'}
-        px={5}
-        py={2}
-      >
-        <Flex align={'flex-end'}>
-          <Text
-            fontSize={'sm'}
-            fontWeight={'semibold'}
-          >
-            {fomattedDate}에 작성된 피드백
-          </Text>
-        </Flex>
-        {isAuthorizedMentor && (
+    <>
+      {isEdit ? (
+        <FeedbackInput
+          value={value}
+          onChange={handleValueChange}
+          onSaveClick={handleEdit}
+          onCancelClick={isEditToggle}
+        />
+      ) : (
+        <BorderBox p={0}>
           <Flex
-            gap={3}
-            align={'end'}
+            justify={'space-between'}
+            borderWidth="1px"
+            borderTopRadius="1.06rem"
+            borderColor={'transparent'}
+            bg={'gray.200'}
+            px={5}
+            py={2}
           >
-            <Box
-              as="button"
-              onClick={handleEdit}
-            >
-              <Tooltip
-                label={LABELS.EDIT}
-                placement="top"
-                hasArrow
+            <Flex align={'flex-end'}>
+              <Text
+                fontSize={'sm'}
+                fontWeight={'semibold'}
               >
-                <span>
-                  <Icon
-                    as={HiPencilAlt}
-                    alignSelf={'flex-end'}
-                  />
-                </span>
-              </Tooltip>
-            </Box>
-            <Box
-              as="button"
-              onClick={handleRemove}
-            >
-              <Tooltip
-                label={LABELS.REMOVE}
-                placement="top"
-                hasArrow
+                {fomattedDate}에 작성된 피드백
+              </Text>
+            </Flex>
+            {isAuthorizedMentor && (
+              <Flex
+                gap={3}
+                align={'end'}
               >
-                <span>
-                  <Icon as={HiTrash} />
-                </span>
-              </Tooltip>
-            </Box>
+                <Box
+                  as="button"
+                  onClick={isEditToggle}
+                >
+                  <Tooltip
+                    label={LABELS.EDIT}
+                    placement="top"
+                    hasArrow
+                  >
+                    <span>
+                      <Icon
+                        as={HiPencilAlt}
+                        alignSelf={'flex-end'}
+                      />
+                    </span>
+                  </Tooltip>
+                </Box>
+                <Box
+                  as="button"
+                  onClick={handleModalOpen}
+                >
+                  <Tooltip
+                    label={LABELS.REMOVE}
+                    placement="top"
+                    hasArrow
+                  >
+                    <span>
+                      <Icon as={HiTrash} />
+                    </span>
+                  </Tooltip>
+                </Box>
+              </Flex>
+            )}
           </Flex>
-        )}
-      </Flex>
-
-      <Divider />
-
-      <Flex
-        px={5}
-        py={3}
-        direction={'column'}
-      >
-        <Box
-          height={'full'}
-          width={'full'}
-          data-color-mode="light"
-          px={1}
-        >
-          <MDEditor.Markdown
-            source={content}
-            style={{ whiteSpace: 'pre-wrap' }}
-          />
-        </Box>
-        <Flex justify={'flex-end'}>
-          <Text
-            fontSize={'xs'}
-            fontWeight={'light'}
-            color={'gray.500'}
+          <Divider />
+          <Flex
+            px={5}
+            py={3}
+            direction={'column'}
           >
-            {fomattedDate}
-          </Text>
-        </Flex>
-      </Flex>
-    </BorderBox>
+            <Box
+              height={'full'}
+              width={'full'}
+              data-color-mode="light"
+              px={1}
+            >
+              <MDEditor.Markdown
+                source={content}
+                style={{ whiteSpace: 'pre-wrap' }}
+              />
+            </Box>
+            <Flex justify={'flex-end'}>
+              <Text
+                fontSize={'xs'}
+                fontWeight={'light'}
+                color={'gray.500'}
+              >
+                {fomattedDate}
+              </Text>
+            </Flex>
+          </Flex>
+          <ConfirmModal
+            isOpen={isOpen}
+            onClose={onClose}
+            message="정말로 삭제하시겠습니까?"
+            proceed={handleRemove}
+          />
+        </BorderBox>
+      )}
+    </>
   );
 };
 

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -7,7 +7,7 @@ import { FeedbackComment } from '~/types/event/feedback';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
 
-type FeedbackResumeDetailsProps<T extends ReadCategories> = {
+type FeedbackCategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
@@ -15,13 +15,13 @@ type FeedbackResumeDetailsProps<T extends ReadCategories> = {
   isFeedbackPage?: boolean;
 };
 
-const FeedbackResumeDetails = <T extends ReadCategories>({
+const FeedbackCategoryDetails = <T extends ReadCategories>({
   arrayData,
   DetailsComponent,
   commentsData,
   isAuthorizedMentor = false,
   isFeedbackPage = false,
-}: FeedbackResumeDetailsProps<T>) => {
+}: FeedbackCategoryDetailsProps<T>) => {
   const indexedComments = getIndexedComments(commentsData);
   const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
 
@@ -49,7 +49,6 @@ const FeedbackResumeDetails = <T extends ReadCategories>({
                         <FeedbackView
                           key={currentComment.commentId}
                           commentId={currentComment.commentId}
-                          componentId={currentComment.componentId}
                           lastModifiedAt={currentComment.lastModifiedAt}
                           content={currentComment.content}
                           isAuthorizedMentor={isAuthorizedMentor}
@@ -74,7 +73,7 @@ const FeedbackResumeDetails = <T extends ReadCategories>({
   );
 };
 
-export default FeedbackResumeDetails;
+export default FeedbackCategoryDetails;
 
 const getIndexedComments = (commentsData: FeedbackComment[]) => {
   const indexedComments: { [blockId: string]: FeedbackComment[] } = {};

--- a/src/components/organisms/FeedbackCategoryDetails/index.ts
+++ b/src/components/organisms/FeedbackCategoryDetails/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackCategoryDetails } from './FeedbackCategoryDetails';

--- a/src/components/organisms/FeedbackResumeDetails/FeedbackResumeDetails.tsx
+++ b/src/components/organisms/FeedbackResumeDetails/FeedbackResumeDetails.tsx
@@ -2,6 +2,7 @@ import { Box, Divider } from '@chakra-ui/react';
 import React from 'react';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { FeedbackView } from '~/components/molecules/FeedbackView';
+import FeedbackBlock from '~/components/templates/FeedbackResumeTemplate/FeedbackBlock';
 import { FeedbackComment } from '~/types/event/feedback';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
@@ -11,6 +12,7 @@ type FeedbackResumeDetailsProps<T extends ReadCategories> = {
   commentsData: FeedbackComment[];
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   isAuthorizedMentor?: boolean;
+  isFeedbackPage?: boolean;
 };
 
 const FeedbackResumeDetails = <T extends ReadCategories>({
@@ -18,9 +20,11 @@ const FeedbackResumeDetails = <T extends ReadCategories>({
   DetailsComponent,
   commentsData,
   isAuthorizedMentor = false,
+  isFeedbackPage = false,
 }: FeedbackResumeDetailsProps<T>) => {
   const indexedComments = getIndexedComments(commentsData);
   const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
+
   return (
     <>
       {arrayData?.length > 0 && (
@@ -31,7 +35,10 @@ const FeedbackResumeDetails = <T extends ReadCategories>({
             const hasComment = commentComponentIds.includes(currentBlockId);
             return (
               <React.Fragment key={index}>
-                <Box position={'relative'}>
+                <Box
+                  position={'relative'}
+                  role="group"
+                >
                   <DetailsComponent
                     data={data}
                     isCurrentUser={false}
@@ -50,6 +57,7 @@ const FeedbackResumeDetails = <T extends ReadCategories>({
                       ))}
                     </>
                   )}
+                  {isFeedbackPage && <FeedbackBlock blockId={data.componentId} />}
                 </Box>
                 {index !== arrayData.length - 1 && (
                   <Divider

--- a/src/components/organisms/FeedbackResumeDetails/index.ts
+++ b/src/components/organisms/FeedbackResumeDetails/index.ts
@@ -1,1 +1,0 @@
-export { default as FeedbackResumeDetails } from './FeedbackResumeDetails';

--- a/src/components/organisms/ResumeCategoryDetails/ResumeCategoryDetails.tsx
+++ b/src/components/organisms/ResumeCategoryDetails/ResumeCategoryDetails.tsx
@@ -1,8 +1,6 @@
 import { Box, Divider } from '@chakra-ui/react';
 import React, { useState } from 'react';
-import { useLocation } from 'react-router-dom';
 import { BorderBox } from '~/components/atoms/BorderBox';
-import FeedbackBlock from '~/components/templates/FeedbackResumeTemplate/FeedbackBlock';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { FormComponentProps } from '~/types/props/formComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
@@ -21,9 +19,6 @@ const ResumeCategoryDetails = <T extends ReadCategories>({
   isCurrentUser = false,
 }: CategoryDetailsProps<T>) => {
   const [editTargetIndex, setEditTargetIndex] = useState<number | null>(null);
-  const currentPath = useLocation().pathname;
-  const feedbackPageRegex = /^\/resume\/\d+\/feedback$/;
-  const isFeedbackPage = feedbackPageRegex.test(currentPath);
 
   return (
     <React.Fragment>
@@ -48,7 +43,6 @@ const ResumeCategoryDetails = <T extends ReadCategories>({
                     onEdit={() => setEditTargetIndex(index)}
                     isCurrentUser={isCurrentUser}
                   />
-                  {isFeedbackPage && <FeedbackBlock blockId={data.componentId} />}
                 </Box>
               )}
               {index !== arrayData.length - 1 && (

--- a/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
+++ b/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import { useParams } from 'react-router-dom';
 import { BorderBox } from '~/components/atoms/BorderBox';
-import { FeedbackResumeDetails } from '~/components/organisms/FeedbackResumeDetails';
+import { FeedbackCategoryDetails } from '~/components/organisms/FeedbackCategoryDetails';
 import {
   ActivityDetails,
   AwardDetails,
@@ -58,7 +58,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     업무경험
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.careers}
                     DetailsComponent={CareerDetails}
                     commentsData={commentResponses}
@@ -75,7 +75,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     프로젝트
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.projects}
                     DetailsComponent={ProjectDetails}
                     commentsData={commentResponses}
@@ -92,7 +92,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     교육
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.trainings}
                     DetailsComponent={TrainingDetails}
                     commentsData={commentResponses}
@@ -109,7 +109,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     수상 및 자격증
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.certifications}
                     DetailsComponent={AwardDetails}
                     commentsData={commentResponses}
@@ -126,7 +126,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     외국어
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.foreignLanguages}
                     DetailsComponent={LanguageDetails}
                     commentsData={commentResponses}
@@ -143,7 +143,7 @@ const FeedbackCompleteTemplate = () => {
                   >
                     활동
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={details.activities}
                     DetailsComponent={ActivityDetails}
                     commentsData={commentResponses}

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
@@ -12,8 +12,8 @@ type FeedbackBlockProps = {
 const LABEL_TEXT = '첨삭하기';
 
 const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
-  const { mutate } = usePostFeedbackComment();
   const { eventId = '', resumeId = '' } = useParams();
+  const { mutate } = usePostFeedbackComment(resumeId, eventId);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [value, setValue] = useState<string>('');
 
@@ -24,14 +24,6 @@ const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
   };
 
   const handleSave = () => {
-    /* TODO POST API 연동
-      - value를 가지고 저장함
-      - 연동에 성공할 경우!
-        - 첨삭 코멘트 렌더링 하는 곳의 쿼리 데이터 변경하기 (최신화) ❌
-        - value reset하기 ⭕
-        - isOpen false로 변경하기 (에디터 안보이게하기) - onClose() ⭕
-    */
-
     const body = {
       componentId: blockId,
       content: value,

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
-import { FeedbackResumeDetails } from '~/components/organisms/FeedbackResumeDetails';
+import { FeedbackCategoryDetails } from '~/components/organisms/FeedbackCategoryDetails';
 import {
   ActivityDetails,
   AwardDetails,
@@ -211,7 +211,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     업무경험
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={data.career}
                     commentsData={commentResponses}
                     DetailsComponent={CareerDetails}
@@ -230,7 +230,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     프로젝트
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     commentsData={commentResponses}
                     arrayData={data.project}
                     DetailsComponent={ProjectDetails}
@@ -249,7 +249,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     교육
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={data.training}
                     commentsData={commentResponses}
                     DetailsComponent={TrainingDetails}
@@ -268,7 +268,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     수상 및 자격증
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={data.award}
                     commentsData={commentResponses}
                     DetailsComponent={AwardDetails}
@@ -287,7 +287,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     외국어
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={data.language}
                     commentsData={commentResponses}
                     DetailsComponent={LanguageDetails}
@@ -306,7 +306,7 @@ const FeedbackResumeTemplate = () => {
                   >
                     활동
                   </Text>
-                  <FeedbackResumeDetails
+                  <FeedbackCategoryDetails
                     arrayData={data.activity}
                     commentsData={commentResponses}
                     DetailsComponent={ActivityDetails}

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'react-router-dom';
 import { BorderBox } from '../../atoms/BorderBox';
 import { Label } from '~/components/atoms/Label';
 import { ReferenceLinkBox } from '~/components/molecules/ReferenceLinkBox';
-import { ResumeCategoryDetails } from '~/components/organisms/ResumeCategoryDetails';
+import { FeedbackResumeDetails } from '~/components/organisms/FeedbackResumeDetails';
 import {
   ActivityDetails,
   AwardDetails,
@@ -15,14 +15,17 @@ import {
 } from '~/components/organisms/ResumeDetails';
 import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
 import { useGetResumeDetails } from '~/queries/resume/details/useGetResumeDetails';
+import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
 import { ReferenceLink } from '~/types/referenceLink';
 import { formatPhoneNumber } from '~/utils/formatPhoneNumber';
 
 const FeedbackResumeTemplate = () => {
-  const { resumeId = '' } = useParams();
-
+  const { resumeId = '', eventId = '' } = useParams();
   const { data: details } = useGetResumeDetails({ resumeId });
   const { data: basicInfo } = useGetResumeBasic({ resumeId });
+  const {
+    data: { commentResponses },
+  } = useGetResumeFeedbacks({ resumeId, eventId });
 
   const data = {
     basic: basicInfo,
@@ -208,9 +211,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     업무경험
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
                     arrayData={data.career}
+                    commentsData={commentResponses}
                     DetailsComponent={CareerDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}
@@ -224,9 +230,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     프로젝트
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
+                    commentsData={commentResponses}
                     arrayData={data.project}
                     DetailsComponent={ProjectDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}
@@ -240,9 +249,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     교육
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
                     arrayData={data.training}
+                    commentsData={commentResponses}
                     DetailsComponent={TrainingDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}
@@ -256,9 +268,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     수상 및 자격증
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
                     arrayData={data.award}
+                    commentsData={commentResponses}
                     DetailsComponent={AwardDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}
@@ -272,9 +287,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     외국어
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
                     arrayData={data.language}
+                    commentsData={commentResponses}
                     DetailsComponent={LanguageDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}
@@ -288,9 +306,12 @@ const FeedbackResumeTemplate = () => {
                   >
                     활동
                   </Text>
-                  <ResumeCategoryDetails
+                  <FeedbackResumeDetails
                     arrayData={data.activity}
+                    commentsData={commentResponses}
                     DetailsComponent={ActivityDetails}
+                    isAuthorizedMentor
+                    isFeedbackPage
                   />
                 </Box>
               )}

--- a/src/queries/event/useDeleteFeedbackComment.ts
+++ b/src/queries/event/useDeleteFeedbackComment.ts
@@ -1,0 +1,39 @@
+import { useToast } from '@chakra-ui/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { feedbackKeys } from '../resume/feedback/feedbackKeys.const';
+import { deleteFeedbackComment } from '~/api/resume/feedback/deleteFeedbackComment';
+import CONSTANTS from '~/constants';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+
+const useDeleteFeedbackComment = (resumeId: string, eventId: string) => {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = feedbackKeys.resumeFeedbacks(resumeId, eventId);
+
+  return useMutation({
+    mutationFn: deleteFeedbackComment,
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: TARGET_QUERY_KEY, type: 'active' });
+      toast({
+        description: '성공적으로 삭제되었습니다 :)',
+        status: 'success',
+      });
+    },
+
+    /**TODO - queryClient에 공통 에러 처리 (onError) 설정해주기 */
+    onError: (error) => {
+      if (isAxiosError<ResumeMeErrorResponse>(error)) {
+        if (error.response) {
+          const errorCode = error.response.data.code;
+          toast({
+            description: CONSTANTS.ERROR_MESSAGES[errorCode],
+            status: 'error',
+          });
+        }
+      }
+    },
+  });
+};
+
+export default useDeleteFeedbackComment;

--- a/src/queries/event/usePatchFeedbackComment.ts
+++ b/src/queries/event/usePatchFeedbackComment.ts
@@ -1,0 +1,38 @@
+import { useToast } from '@chakra-ui/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
+import { feedbackKeys } from '../resume/feedback/feedbackKeys.const';
+import { patchFeedbackComment } from '~/api/resume/feedback/patchFeedbackComment';
+import CONSTANTS from '~/constants';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+
+const usePatchFeedbackComment = (resumeId: string, eventId: string) => {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = feedbackKeys.resumeFeedbacks(resumeId, eventId);
+
+  return useMutation({
+    mutationFn: patchFeedbackComment,
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: TARGET_QUERY_KEY, type: 'active' });
+      toast({
+        description: '성공적으로 수정되었습니다 :)',
+        status: 'success',
+      });
+    },
+    /**TODO - queryClient에 공통 에러 처리 (onError) 설정해주기 */
+    onError: (error) => {
+      if (isAxiosError<ResumeMeErrorResponse>(error)) {
+        if (error.response) {
+          const errorCode = error.response.data.code;
+          toast({
+            description: CONSTANTS.ERROR_MESSAGES[errorCode],
+            status: 'error',
+          });
+        }
+      }
+    },
+  });
+};
+
+export default usePatchFeedbackComment;

--- a/src/queries/event/usePostFeedbackComment.ts
+++ b/src/queries/event/usePostFeedbackComment.ts
@@ -1,31 +1,40 @@
 import { useToast } from '@chakra-ui/react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
+import { feedbackKeys } from '../resume/feedback/feedbackKeys.const';
 import { postFeedbackComment } from '~/api/resume/feedback/postFeedbackComment';
 import CONSTANTS from '~/constants';
 import { ResumeMeErrorResponse } from '~/types/errorResponse';
 
-const usePostFeedbackComment = () => {
+const usePostFeedbackComment = (resumeId: string, eventId: string) => {
+  const queryClient = useQueryClient();
+  const TARGET_QUERY_KEY = feedbackKeys.resumeFeedbacks(resumeId, eventId);
   const toast = useToast();
+
   return useMutation({
     mutationFn: postFeedbackComment,
-    onSuccess: () => {
+    onSuccess: async () => {
       toast({
         description: '저장되었어요 :)',
         status: 'success',
       });
+      queryClient.refetchQueries({ queryKey: TARGET_QUERY_KEY, type: 'active' });
     },
-    /**TODO - queryClient에 공통 에러 처리 (onError) 설정해주기 */
-    onError: (error) => {
-      if (isAxiosError<ResumeMeErrorResponse>(error)) {
-        if (error.response) {
-          const errorCode = error.response.data.code;
+    onError: (err) => {
+      if (isAxiosError<ResumeMeErrorResponse>(err)) {
+        if (err.response) {
+          const errorCode = err.response.data.code;
           toast({
             description: CONSTANTS.ERROR_MESSAGES[errorCode],
             status: 'error',
           });
         }
       }
+      toast({
+        title: '서버에 문제가 생겼습니다.',
+        description: '다시 시도해주세요.',
+        status: 'error',
+      });
     },
   });
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![Screenshot 2023-11-23 at 04 34 48-feedback](https://github.com/resumeme/Frontend/assets/74141521/f0ced942-a4e6-47e3-acd7-61d5e6a105c4)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 이력서 첨삭 페이지
- **API 함수 및 쿼리 작성**
  - 첨삭 코멘트 작성, 수정, 삭제 함수 및 쿼리
- **첨삭 관련 페이지들은 `ResumeCategoryDetails`가 아닌 `FeedbackCategoryDetails` 컴포넌트를 사용하는 것으로 변경**
  - 기존에 임시적으로 `ResumeCategoryDetails`에 렌더링했던 `FeedbackInput` 라인을 제거
- **`FeedbackView`에 수정과 삭제 기능을 추가**
  - `FeedbackBlock`은 코멘트 작성 인풋을 새로 렌더링하도록 하고, 기존에 작성되어있던 첨삭 코멘트는 `FeedbackView`에서 렌더링 및 수정 삭제 기능을 담당

### 지엽적 변화
- `ConfirmModal` 컴포넌트의 렌더링 위치를 상단 -> 중앙으로 수정했습니다.
- 통일성을 위해 `FeedbackResumeDetails`의 이름을 `FeedbackCategoryDetails`로 수정했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
### 서버 로직 문제
- 첨삭 코멘트를 삭제할 시, `content` 내용만 `null`처리 되고 해당 객체 자체는 사라지지 않아 렌더링 문제가 생기고 있습니다.

<div align="center">

![image](https://github.com/resumeme/Frontend/assets/74141521/b2e91985-49b3-404f-ba5f-6165709e0f94)
**[삭제한 코멘트 객체가 남아있음]** 

<br />
<br />

![image](https://github.com/resumeme/Frontend/assets/74141521/00d48ebc-0d5f-4f3e-977f-bddf5be4ce32)
**[화면에 블록이 렌더링 됨]**

</div>

## 🔎 PR포인트 및 궁금한 점
