### PR TITLE
Gmmq 644 style: 피드백 뷰어 UI 스타일 변경 및 에러 수정

### DIFF
--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -1,11 +1,11 @@
-import { Box, Flex, Text, Divider, Icon, Tooltip, useDisclosure } from '@chakra-ui/react';
+import { Box, Flex, Text, Icon, Image, Tooltip, useDisclosure, Divider } from '@chakra-ui/react';
 import MDEditor from '@uiw/react-md-editor';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { HiPencilAlt, HiTrash } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 import { ConfirmModal } from '../ConfirmModal';
 import { FeedbackInput } from '../FeedbackInput';
-import { BorderBox } from '~/components/atoms/BorderBox';
+import { Label } from '~/components/atoms/Label';
 import useDeleteFeedbackComment from '~/queries/event/useDeleteFeedbackComment';
 import usePatchFeedbackComment from '~/queries/event/usePatchFeedbackComment';
 import { formatKoreanDateWithoutSeconds } from '~/utils/formatDate';
@@ -21,12 +21,13 @@ type FeedbackViewProps = {
 const LABELS = {
   EDIT: '수정하기',
   REMOVE: '삭제하기',
-  HEADER: '첨삭',
+  BLOCK: '피드백',
 };
 
+const BGCOLOR = '#fbfffc';
+
 const FeedbackView = ({
-  content = `## 테스트
-- **반갑습니다.**`,
+  content = ``,
   lastModifiedAt = '2023-11-15 17:17:09',
   commentId,
   isAuthorizedMentor = false,
@@ -37,6 +38,12 @@ const FeedbackView = ({
   const { mutate: patchCommentMutate } = usePatchFeedbackComment(resumeId, eventId);
   const { mutate: deleteCommentMutate } = useDeleteFeedbackComment(resumeId, eventId);
   const { isOpen, onOpen, onClose } = useDisclosure();
+
+  useEffect(() => {
+    if (content !== '') {
+      setValue(content);
+    }
+  }, [value, content]);
 
   const isEditToggle = () => {
     setIsEdit(!isEdit);
@@ -87,97 +94,158 @@ const FeedbackView = ({
           onCancelClick={isEditToggle}
         />
       ) : (
-        <BorderBox p={0}>
-          <Flex
-            justify={'space-between'}
-            borderWidth="1px"
-            borderTopRadius="1.06rem"
-            borderColor={'transparent'}
-            bg={'gray.200'}
-            px={5}
-            py={2}
+        <>
+          <Box
+            role="group"
+            borderTop={'1px solid'}
+            borderBottom={'1px solid'}
+            // borderRadius={'lg'}
+            borderColor={'gray.300'}
+            position={'relative'}
+            bg={BGCOLOR}
+            mt={8}
           >
-            <Flex align={'flex-end'}>
-              <Text
-                fontSize={'sm'}
-                fontWeight={'semibold'}
-              >
-                {fomattedDate}에 작성된 피드백
-              </Text>
-            </Flex>
-            {isAuthorizedMentor && (
-              <Flex
-                gap={3}
-                align={'end'}
-              >
-                <Box
-                  as="button"
-                  onClick={isEditToggle}
-                >
-                  <Tooltip
-                    label={LABELS.EDIT}
-                    placement="top"
-                    hasArrow
-                  >
-                    <span>
-                      <Icon
-                        as={HiPencilAlt}
-                        alignSelf={'flex-end'}
-                      />
-                    </span>
-                  </Tooltip>
-                </Box>
-                <Box
-                  as="button"
-                  onClick={handleModalOpen}
-                >
-                  <Tooltip
-                    label={LABELS.REMOVE}
-                    placement="top"
-                    hasArrow
-                  >
-                    <span>
-                      <Icon as={HiTrash} />
-                    </span>
-                  </Tooltip>
-                </Box>
-              </Flex>
-            )}
-          </Flex>
-          <Divider />
-          <Flex
-            px={5}
-            py={3}
-            direction={'column'}
-          >
-            <Box
-              height={'full'}
-              width={'full'}
-              data-color-mode="light"
-              px={1}
+            <Flex
+              w={'full'}
+              position="absolute"
+              top={'-12px'}
+              // left={'-5px'}
+              justify={'space-between'}
+              pr={2}
+              pl={1}
             >
-              <MDEditor.Markdown
-                source={content}
-                style={{ whiteSpace: 'pre-wrap' }}
-              />
-            </Box>
-            <Flex justify={'flex-end'}>
-              <Text
-                fontSize={'xs'}
-                fontWeight={'light'}
-                color={'gray.500'}
+              <Flex
+                gap={2}
+                align={'center'}
+                justify={'center'}
+                bg={'white'}
+                rounded={'full'}
+                border={'1px solid'}
+                borderColor={'gray.300'}
+                borderRadius={'full'}
+                pr={2}
+                pl={1}
+                py={1}
               >
-                {fomattedDate}
-              </Text>
+                <Tooltip
+                  label={'카키디'}
+                  placement="top"
+                  hasArrow
+                >
+                  <Image
+                    borderRadius="full"
+                    boxSize="24px"
+                    /* FIXME 멘토 아이콘 */
+                    src="https://bit.ly/dan-abramov"
+                  />
+                </Tooltip>
+                <Text
+                  fontSize={'xs'}
+                  fontWeight={'bold'}
+                  color={'gray.800'}
+                >
+                  {/* FIXME 멘토 닉네임 */}
+                  카키디
+                </Text>
+              </Flex>
+              {isAuthorizedMentor ? (
+                <Flex
+                  gap={3}
+                  align={'center'}
+                  justify={'center'}
+                  rounded={'full'}
+                  bg={'white'}
+                  border={'1px'}
+                  borderColor={'gray.300'}
+                  borderRadius={'full'}
+                  px={3}
+                >
+                  <Box
+                    as="button"
+                    onClick={isEditToggle}
+                  >
+                    <Tooltip
+                      label={LABELS.EDIT}
+                      placement="top"
+                      hasArrow
+                    >
+                      <Flex>
+                        <Icon as={HiPencilAlt} />
+                      </Flex>
+                    </Tooltip>
+                  </Box>
+                  <Divider
+                    borderColor={'gray.400'}
+                    orientation="vertical"
+                    h={'60%'}
+                  />
+                  <Box
+                    as="button"
+                    onClick={handleModalOpen}
+                  >
+                    <Tooltip
+                      label={LABELS.REMOVE}
+                      placement="top"
+                      hasArrow
+                    >
+                      <Flex>
+                        <Icon as={HiTrash} />
+                      </Flex>
+                    </Tooltip>
+                  </Box>
+                </Flex>
+              ) : (
+                <Label
+                  py={0}
+                  bg={'white'}
+                  border={'1px solid'}
+                  borderColor={'gray.300'}
+                  fontSize={'2xs'}
+                  color={'primary.900'}
+                >
+                  {LABELS.BLOCK}
+                </Label>
+              )}
             </Flex>
-          </Flex>
-          <ConfirmModal
-            isOpen={isOpen}
-            onClose={onClose}
-            message="정말로 삭제하시겠습니까?"
-            proceed={handleRemove}
-          />
-        </BorderBox>
+            <Flex
+              direction={'column'}
+              px={2}
+              pb={2}
+              pt={4}
+            >
+              <Box
+                height={'full'}
+                width={'full'}
+                data-color-mode="light"
+                p={4}
+                my={2}
+              >
+                <MDEditor.Markdown
+                  source={content}
+                  style={{ whiteSpace: 'pre-wrap', backgroundColor: BGCOLOR }}
+                />
+              </Box>
+              <Flex
+                justify={'flex-end'}
+                mr={1}
+              >
+                <Text
+                  fontSize={'2xs'}
+                  fontWeight={'light'}
+                  color={'gray.400'}
+                >
+                  {fomattedDate}
+                </Text>
+              </Flex>
+            </Flex>
+            <ConfirmModal
+              isOpen={isOpen}
+              onClose={onClose}
+              message="정말로 삭제하시겠습니까?"
+              proceed={handleRemove}
+            />
+          </Box>
+        </>
       )}
     </>
   );

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -38,6 +38,7 @@ const FeedbackCategoryDetails = <T extends ReadCategories>({
                 <Box
                   position={'relative'}
                   role="group"
+                  pb={7}
                 >
                   <DetailsComponent
                     data={data}

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
@@ -67,7 +67,7 @@ const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
             placement="top"
           >
             <PlusSquareIcon
-              color={'red'}
+              color={'gray.500'}
               boxSize={6}
               _groupHover={{
                 color: 'primary.900',


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<div align="center">


![image](https://github.com/resumeme/Frontend/assets/74141521/4a49f907-2489-4cac-b1c2-ef4be0e1dd3d)


**[변경 전 UI 디자인]**

<br />
<br />


![image](https://github.com/resumeme/Frontend/assets/74141521/1c104b0a-256c-40ee-90ff-d10c2bf9e887)


**[변경 후 UI 디자인]**


</div>


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 에러 수정
**수정 시 인풋에 값이 없는 에러를 해결했습니다.**
- `useEffect`로 value 값에 content 값을 넣어주었습니다.

### 스타일 수정
- 스타일 변경되었습니다.
- 코멘트를 작성하는 멘토 회원의 닉네임과 프로필 사진 url이 필요합니다.
  - 지금은 목업 데이터로 들어가 있습니다.






## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
