### PR TITLE
Gmmq 648 feat: 첨삭 반영 페이지 생성, 복사본 + 원본 + 코멘트 데이터 뿌려주기

### DIFF
--- a/src/components/atoms/AccordionToggle/AccordionToggle.tsx
+++ b/src/components/atoms/AccordionToggle/AccordionToggle.tsx
@@ -14,6 +14,7 @@ type AccordionToggleProps = AccordionProps & {
   panelPx?: string;
   panelPy?: string;
   fontSize?: string;
+  isOpen?: boolean;
   children: React.ReactNode;
 };
 
@@ -22,6 +23,7 @@ const AccordionToggle = ({
   panelPx = '0',
   panelPy = '1rem',
   fontSize = 'sm',
+  isOpen = false,
   children,
   ...props
 }: AccordionToggleProps) => {
@@ -29,6 +31,7 @@ const AccordionToggle = ({
     <Flex>
       <Accordion
         allowToggle
+        defaultIndex={isOpen ? [0] : []}
         {...props}
       >
         <AccordionItem

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -6,6 +6,7 @@ import FeedbackBlock from '~/components/templates/FeedbackResumeTemplate/Feedbac
 import { FeedbackComment } from '~/types/event/feedback';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
+import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
 
 type FeedbackCategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
@@ -22,7 +23,7 @@ const FeedbackCategoryDetails = <T extends ReadCategories>({
   isAuthorizedMentor = false,
   isFeedbackPage = false,
 }: FeedbackCategoryDetailsProps<T>) => {
-  const indexedComments = getIndexedComments(commentsData);
+  const indexedComments = getIndexedCommentsObject(commentsData);
   const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
 
   return (
@@ -74,16 +75,3 @@ const FeedbackCategoryDetails = <T extends ReadCategories>({
 };
 
 export default FeedbackCategoryDetails;
-
-const getIndexedComments = (commentsData: FeedbackComment[]) => {
-  const indexedComments: { [blockId: string]: FeedbackComment[] } = {};
-  commentsData.forEach((commentItem) => {
-    const componentId = commentItem.componentId;
-    if (!indexedComments[componentId]) {
-      indexedComments[componentId] = [{ ...commentItem }];
-      return;
-    }
-    indexedComments[componentId].push({ ...commentItem });
-  });
-  return indexedComments;
-};

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -40,6 +40,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
             const currentBlockId = data.componentId;
             const targetComments: FeedbackComment[] = indexedComments[currentBlockId];
             const hasComment = commentComponentIds.includes(currentBlockId);
+            const isOpen = hasComment ?? !data.reflectFeedback;
             return (
               <React.Fragment key={index}>
                 {editTargetIndex === index && FormComponent ? (
@@ -72,6 +73,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                   <AccordionToggle
                     text="첨삭 코멘트가 달려있어요! (੭˙ ˘ ˙)੭"
                     w={'full'}
+                    isOpen={isOpen}
                   >
                     <>
                       {targetComments.map((currentComment) => (

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -1,0 +1,91 @@
+import { Divider, Box } from '@chakra-ui/react';
+import React from 'react';
+import { useState } from 'react';
+import { AccordionToggle } from '~/components/atoms/AccordionToggle';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { FeedbackView } from '~/components/molecules/FeedbackView';
+import { FeedbackComment } from '~/types/event/feedback';
+import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
+import { FormComponentProps } from '~/types/props/formComponentProps';
+import { ReadCategories } from '~/types/resume/categories';
+import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
+
+type CategoryDetailsProps<T extends ReadCategories> = {
+  arrayData: T[];
+  commentsData: FeedbackComment[];
+  DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
+  FormComponent?: React.ComponentType<FormComponentProps<T>>;
+  isCurrentUser: boolean;
+};
+
+const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
+  arrayData,
+  commentsData,
+  DetailsComponent,
+  FormComponent,
+  isCurrentUser,
+}: CategoryDetailsProps<T>) => {
+  const [editTargetIndex, setEditTargetIndex] = useState<number | null>(null);
+  const indexedComments = getIndexedCommentsObject(commentsData);
+  const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
+
+  return (
+    <>
+      {arrayData?.length > 0 && (
+        <BorderBox variant={'wide'}>
+          {arrayData.map((data: T, index: number) => {
+            const currentBlockId = data.componentId;
+            const targetComments: FeedbackComment[] = indexedComments[currentBlockId];
+            const hasComment = commentComponentIds.includes(currentBlockId);
+            return (
+              <React.Fragment key={index}>
+                {editTargetIndex === index && FormComponent ? (
+                  <FormComponent
+                    defaultValues={{ ...data, id: undefined }}
+                    isEdit
+                    blockId={data.componentId}
+                    quitEdit={() => setEditTargetIndex(null)}
+                  />
+                ) : (
+                  <Box
+                    position={'relative'}
+                    role="group"
+                  >
+                    <DetailsComponent
+                      data={data}
+                      onEdit={() => setEditTargetIndex(index)}
+                      isCurrentUser={isCurrentUser}
+                    />
+                  </Box>
+                )}
+                {/**NOTE - 첨삭 코멘트 id와 현재 블럭 id 비교 후 일치하면 아래를 렌더링 */}
+                <AccordionToggle text="첨삭 코멘트가 달려있어요! (੭˙ ˘ ˙)੭">
+                  {hasComment && (
+                    <>
+                      {targetComments.map((currentComment) => (
+                        <FeedbackView
+                          key={currentComment.commentId}
+                          commentId={currentComment.commentId}
+                          lastModifiedAt={currentComment.lastModifiedAt}
+                          content={currentComment.content}
+                        />
+                      ))}
+                    </>
+                  )}
+                </AccordionToggle>
+                {index !== arrayData.length - 1 && (
+                  <Divider
+                    my={'3rem'}
+                    borderColor={'gray.300'}
+                  />
+                )}
+              </React.Fragment>
+            );
+          })}
+        </BorderBox>
+      )}
+    </>
+  );
+};
+
+export default FeedbackCategoryReflectDetails;

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -13,6 +13,7 @@ import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
 type CategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
+  snapshotData: T[];
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   FormComponent?: React.ComponentType<FormComponentProps<T>>;
   isCurrentUser: boolean;
@@ -21,6 +22,7 @@ type CategoryDetailsProps<T extends ReadCategories> = {
 const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
   arrayData,
   commentsData,
+  snapshotData,
   DetailsComponent,
   FormComponent,
   isCurrentUser,
@@ -28,7 +30,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
   const [editTargetIndex, setEditTargetIndex] = useState<number | null>(null);
   const indexedComments = getIndexedCommentsObject(commentsData);
   const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
-
+  const indexedSnapshots = getIndexedSnapshotObject(snapshotData);
   return (
     <>
       {arrayData?.length > 0 && (
@@ -41,7 +43,14 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
               <React.Fragment key={index}>
                 {editTargetIndex === index && FormComponent ? (
                   <FormComponent
-                    defaultValues={{ ...data, id: undefined }}
+                    defaultValues={{
+                      ...data,
+                      componentId: undefined,
+                      reflectFeedback: undefined,
+                      type: undefined,
+                      originComponentId: undefined,
+                      createdDate: undefined,
+                    }}
                     isEdit
                     blockId={data.componentId}
                     quitEdit={() => setEditTargetIndex(null)}
@@ -58,9 +67,11 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                     />
                   </Box>
                 )}
-                {/**NOTE - 첨삭 코멘트 id와 현재 블럭 id 비교 후 일치하면 아래를 렌더링 */}
-                <AccordionToggle text="첨삭 코멘트가 달려있어요! (੭˙ ˘ ˙)੭">
-                  {hasComment && (
+                {hasComment && (
+                  <AccordionToggle
+                    text="첨삭 코멘트가 달려있어요! (੭˙ ˘ ˙)੭"
+                    w={'full'}
+                  >
                     <>
                       {targetComments.map((currentComment) => (
                         <FeedbackView
@@ -71,8 +82,14 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                         />
                       ))}
                     </>
-                  )}
-                </AccordionToggle>
+                    {data.reflectFeedback && (
+                      <DetailsComponent
+                        data={indexedSnapshots[data.componentId]}
+                        isCurrentUser={false}
+                      />
+                    )}
+                  </AccordionToggle>
+                )}
                 {index !== arrayData.length - 1 && (
                   <Divider
                     my={'3rem'}
@@ -89,3 +106,12 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
 };
 
 export default FeedbackCategoryReflectDetails;
+
+const getIndexedSnapshotObject = <T extends ReadCategories>(snapshotData: T[]) => {
+  const indexedSnapshot: { [blockId: string]: T } = {};
+  snapshotData.forEach((commentItem) => {
+    const componentId = commentItem.componentId;
+    indexedSnapshot[componentId] = commentItem;
+  });
+  return indexedSnapshot;
+};

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -30,6 +30,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
   const [editTargetIndex, setEditTargetIndex] = useState<number | null>(null);
   const indexedComments = getIndexedCommentsObject(commentsData);
   const commentComponentIds = Object.keys(indexedComments).map((index) => parseInt(index));
+  if (!snapshotData) return;
   const indexedSnapshots = getIndexedSnapshotObject(snapshotData);
   return (
     <>

--- a/src/components/organisms/FeedbackCateogryReflectDetails/index.ts
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackCategoryReflectDetails } from './FeedbackCategoryReflectDetails';

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -22,7 +22,7 @@ const FeedbackManagementItem = ({
     if (status === 'CLOSE') {
       navigate(appPaths.feedbackComplete(resumeId, eventId));
     } else {
-      navigate(appPaths.resumeEdit(resumeId));
+      navigate(appPaths.feedbackReflect(resumeId, eventId));
     }
   };
 

--- a/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
+++ b/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
@@ -27,7 +27,7 @@ const ActivityForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Activity>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     setValue,

--- a/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
+++ b/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
@@ -27,7 +27,7 @@ const AwardForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Award>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     register,

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -72,7 +72,6 @@ const CareerForm = ({
     if (!resumeId) {
       return;
     }
-    console.log('isEdit', isEdit, 'blockId', blockId);
     body.skills = skills;
     body.duties = body.duties || [];
     if (!isEdit) {

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -36,7 +36,7 @@ const CareerForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Career>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     control,
@@ -72,6 +72,7 @@ const CareerForm = ({
     if (!resumeId) {
       return;
     }
+    console.log('isEdit', isEdit, 'blockId', blockId);
     body.skills = skills;
     body.duties = body.duties || [];
     if (!isEdit) {

--- a/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
+++ b/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
@@ -24,7 +24,7 @@ const LanguageForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Language>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     register,

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -28,7 +28,7 @@ const ProjectForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Project>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     watch,

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -26,7 +26,7 @@ const TrainingForm = ({
   blockId,
   quitEdit,
 }: FormComponentProps<Training>) => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const {
     watch,

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -27,7 +27,7 @@ import { useGetResumeProject } from '~/queries/resume/details/useGetResumeProjec
 import { useGetResumeTraining } from '~/queries/resume/details/useGetResumeTraining';
 
 const EditResumeTemplate = () => {
-  const { id: resumeId = '' } = useParams();
+  const { resumeId = '' } = useParams();
   const { data: basicInfo } = useGetResumeBasic({ resumeId });
   const { data: careersData } = useGetResumeCareer({ resumeId });
   const { data: trainingsData } = useGetResumeTraining({ resumeId });

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -1,5 +1,137 @@
+import { Flex } from '@chakra-ui/react';
+import { useParams } from 'react-router-dom';
+import { FeedbackCategoryReflectDetails } from '~/components/organisms/FeedbackCateogryReflectDetails';
+import { ResumeBasicInput } from '~/components/organisms/ResumeBasicInput';
+import { ActivityForm } from '~/components/organisms/ResumeCategoryActivity';
+import { AwardForm } from '~/components/organisms/ResumeCategoryAwards';
+import CareerForm from '~/components/organisms/ResumeCategoryCareer/CareerForm';
+import { LanguageForm } from '~/components/organisms/ResumeCategoryLanguage';
+import ProjectForm from '~/components/organisms/ResumeCategoryProject/ProjectForm';
+import { TrainingForm } from '~/components/organisms/ResumeCategoryTraining';
+import {
+  ActivityDetails,
+  AwardDetails,
+  CareerDetails,
+  LanguageDetails,
+  ProjectDetails,
+  TrainingDetails,
+} from '~/components/organisms/ResumeDetails';
+import useUser from '~/hooks/useUser';
+import {
+  useGetResumeActivities,
+  useGetResumeAward,
+  useGetResumeCareer,
+  useGetResumeLanguage,
+  useGetResumeProject,
+  useGetResumeTraining,
+} from '~/queries/resume/details';
+import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
+import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
+
 const FeedbackReflectTemplate = () => {
-  return <></>;
+  const { resumeId = '', eventId = '' } = useParams();
+  const { data: basicInfo } = useGetResumeBasic({ resumeId });
+  const { data: careersData } = useGetResumeCareer({ resumeId });
+  const { data: trainingsData } = useGetResumeTraining({ resumeId });
+  const { data: languageData } = useGetResumeLanguage({ resumeId });
+  const { data: projectData } = useGetResumeProject({ resumeId });
+  const { data: activitiesData } = useGetResumeActivities({ resumeId });
+  const { data: awardData } = useGetResumeAward({ resumeId });
+
+  const resumeAuthorId = basicInfo.ownerInfo?.id;
+  const { user } = useUser();
+  const isCurrentUser = resumeAuthorId === user?.id;
+
+  const {
+    data: { commentResponses },
+  } = useGetResumeFeedbacks({ resumeId, eventId });
+
+  return (
+    <Flex
+      width="960px"
+      direction="column"
+      gap="3rem"
+    >
+      <ResumeBasicInput basicInfo={basicInfo} />
+
+      <CategoryContainer>
+        <CareerForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={careersData}
+          DetailsComponent={CareerDetails}
+          FormComponent={CareerForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+
+      <CategoryContainer>
+        <ProjectForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={projectData}
+          DetailsComponent={ProjectDetails}
+          FormComponent={ProjectForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+
+      <CategoryContainer>
+        <AwardForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={awardData}
+          DetailsComponent={AwardDetails}
+          FormComponent={AwardForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+
+      <CategoryContainer>
+        <LanguageForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={languageData}
+          DetailsComponent={LanguageDetails}
+          FormComponent={LanguageForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+
+      <CategoryContainer>
+        <TrainingForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={trainingsData}
+          DetailsComponent={TrainingDetails}
+          FormComponent={TrainingForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+
+      <CategoryContainer>
+        <ActivityForm />
+        <FeedbackCategoryReflectDetails
+          arrayData={activitiesData}
+          DetailsComponent={ActivityDetails}
+          FormComponent={ActivityForm}
+          isCurrentUser={isCurrentUser}
+          commentsData={commentResponses}
+        />
+      </CategoryContainer>
+    </Flex>
+  );
 };
 
 export default FeedbackReflectTemplate;
+
+const CategoryContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Flex
+      direction={'column'}
+      gap={'1rem'}
+    >
+      {children}
+    </Flex>
+  );
+};

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -1,0 +1,5 @@
+const FeedbackReflectTemplate = () => {
+  return <></>;
+};
+
+export default FeedbackReflectTemplate;

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -26,6 +26,7 @@ import {
   useGetResumeTraining,
 } from '~/queries/resume/details';
 import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
+import { useGetSnapshotResume } from '~/queries/resume/details/useGetSnapshotResume';
 import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
 
 const FeedbackReflectTemplate = () => {
@@ -46,6 +47,10 @@ const FeedbackReflectTemplate = () => {
     data: { commentResponses },
   } = useGetResumeFeedbacks({ resumeId, eventId });
 
+  const { data: snapshotData } = useGetSnapshotResume({
+    resumeId,
+  });
+
   return (
     <Flex
       width="960px"
@@ -62,6 +67,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={CareerForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.careers}
         />
       </CategoryContainer>
 
@@ -73,6 +79,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={ProjectForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.projects}
         />
       </CategoryContainer>
 
@@ -84,6 +91,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={AwardForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.certifications}
         />
       </CategoryContainer>
 
@@ -95,6 +103,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={LanguageForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.foreignLanguages}
         />
       </CategoryContainer>
 
@@ -106,6 +115,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={TrainingForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.trainings}
         />
       </CategoryContainer>
 
@@ -117,6 +127,7 @@ const FeedbackReflectTemplate = () => {
           FormComponent={ActivityForm}
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
+          snapshotData={snapshotData.activities}
         />
       </CategoryContainer>
     </Flex>

--- a/src/components/templates/FeedbackReflectTemplate/index.ts
+++ b/src/components/templates/FeedbackReflectTemplate/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackReflectTemplate } from './FeedbackReflectTemplate';

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -23,7 +23,7 @@ import { ReadReferenceLink } from '~/types/referenceLink';
 import { formatPhoneNumber } from '~/utils/formatPhoneNumber';
 
 const ResumeDetailTemplate = () => {
-  const { id: resumeId } = useParams() as { id: string };
+  const { resumeId = '' } = useParams();
 
   const { data: details } = useGetResumeDetails({ resumeId });
   const { data: basicInfo } = useGetResumeBasic({ resumeId });

--- a/src/config/paths.ts
+++ b/src/config/paths.ts
@@ -14,4 +14,6 @@ export const appPaths = {
     `/resume/${resumeId}/event/${eventId}/feedback`,
   feedbackResume: ({ resumeId, eventId }: { resumeId: number; eventId: number }) =>
     `/event/${eventId}/resume/${resumeId}`,
+  feedbackReflect: (resumeId: number, eventId: number) =>
+    `/event/${eventId}/resume/${resumeId}/feedback/reflect`,
 };

--- a/src/pages/ResumePages/FeedbackReflectPage/FeedbackReflectPage.tsx
+++ b/src/pages/ResumePages/FeedbackReflectPage/FeedbackReflectPage.tsx
@@ -1,0 +1,7 @@
+import { FeedbackReflectTemplate } from '~/components/templates/FeedbackReflectTemplate';
+
+const FeedbackReflectPage = () => {
+  return <FeedbackReflectTemplate />;
+};
+
+export default FeedbackReflectPage;

--- a/src/pages/ResumePages/FeedbackReflectPage/index.ts
+++ b/src/pages/ResumePages/FeedbackReflectPage/index.ts
@@ -1,0 +1,1 @@
+export { default as FeedbackReflectPage } from './FeedbackReflectPage';

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -38,11 +38,11 @@ const router = createBrowserRouter([
 
       { path: 'resume/create', element: <CreateResumePage /> },
       { path: 'resume/management', element: <ManagementResumePage /> },
-      { path: 'resume/:id/edit', element: <EditResumePage /> },
+      { path: 'resume/:resumeId/edit', element: <EditResumePage /> },
 
       { path: 'resume/:resumeId/event/:eventId/feedback', element: <FeedbackCompletePage /> },
 
-      { path: 'resume/:id', element: <ResumeDetailPage /> },
+      { path: 'resume/:resumeId', element: <ResumeDetailPage /> },
       { path: 'write-review', element: <WriteReviewPage /> },
 
       { path: 'event/create', element: <CreateEventPage /> },

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -67,7 +67,7 @@ const router = createBrowserRouter([
     element: <FeedbackLayout />,
     children: [
       { index: true, element: <FeedbackResumePage /> },
-      { path: '/feedback/reflect', element: <FeedbackReflectPage /> },
+      { path: 'feedback/reflect', element: <FeedbackReflectPage /> },
     ],
   },
 ]);

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -14,6 +14,7 @@ import { EditProfilePage } from '~/pages/ProfilePages/EditProfilePage';
 import { CreateResumePage } from '~/pages/ResumePages/CreateResumePage';
 import { EditResumePage } from '~/pages/ResumePages/EditResumePage';
 import { FeedbackCompletePage } from '~/pages/ResumePages/FeedbackCompletePage';
+import { FeedbackReflectPage } from '~/pages/ResumePages/FeedbackReflectPage';
 import { FeedbackResumePage } from '~/pages/ResumePages/FeedbackResumePage';
 import { ManagementResumePage } from '~/pages/ResumePages/ManagementResumePage';
 import { ResumeDetailPage } from '~/pages/ResumePages/ResumeDetailPage';
@@ -64,7 +65,10 @@ const router = createBrowserRouter([
   {
     path: 'event/:eventId/resume/:resumeId/',
     element: <FeedbackLayout />,
-    children: [{ index: true, element: <FeedbackResumePage /> }],
+    children: [
+      { index: true, element: <FeedbackResumePage /> },
+      { path: '/feedback/reflect', element: <FeedbackReflectPage /> },
+    ],
   },
 ]);
 

--- a/src/types/activity.ts
+++ b/src/types/activity.ts
@@ -7,6 +7,10 @@ type Activity = {
   description?: string;
 };
 
-type ReadActivity = Activity & { componentId: number };
+type ReadActivity = Activity & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 export type { Activity, ReadActivity };

--- a/src/types/award.ts
+++ b/src/types/award.ts
@@ -6,6 +6,10 @@ type Award = {
   description?: string;
 };
 
-type ReadAward = Award & { componentId: number };
+type ReadAward = Award & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 export type { Award, ReadAward };

--- a/src/types/career.ts
+++ b/src/types/career.ts
@@ -16,6 +16,10 @@ type Duty = {
   endDate?: string;
 };
 
-type ReadCareer = Career & { componentId: number };
+type ReadCareer = Career & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 export type { Career, ReadCareer };

--- a/src/types/language.ts
+++ b/src/types/language.ts
@@ -4,6 +4,10 @@ type Language = {
   scoreOrGrade: string;
 };
 
-type ReadLanguage = Language & { componentId: number };
+type ReadLanguage = Language & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 export type { Language, ReadLanguage };

--- a/src/types/project.ts
+++ b/src/types/project.ts
@@ -8,7 +8,11 @@ type Project = {
   projectUrl?: string;
 };
 
-type ReadProject = Project & { componentId: number };
+type ReadProject = Project & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 type ProjectForm = {
   isTeam: boolean | string;

--- a/src/types/training.ts
+++ b/src/types/training.ts
@@ -9,6 +9,10 @@ type Training = {
   explanation?: string;
 };
 
-type ReadTraining = Training & { componentId: number };
+type ReadTraining = Training & {
+  componentId: number;
+  reflectFeedback: boolean;
+  originComponentId: number | null;
+};
 
 export type { Training, ReadTraining };

--- a/src/utils/getIndexedCommentsObject.ts
+++ b/src/utils/getIndexedCommentsObject.ts
@@ -1,0 +1,14 @@
+import { FeedbackComment } from '~/types/event/feedback';
+
+export const getIndexedCommentsObject = (commentsData: FeedbackComment[]) => {
+  const indexedComments: { [blockId: string]: FeedbackComment[] } = {};
+  commentsData.forEach((commentItem) => {
+    const componentId = commentItem.componentId;
+    if (!indexedComments[componentId]) {
+      indexedComments[componentId] = [{ ...commentItem }];
+      return;
+    }
+    indexedComments[componentId].push({ ...commentItem });
+  });
+  return indexedComments;
+};


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<img width="1014" alt="스크린샷 2023-11-24 오전 12 55 21" src="https://github.com/resumeme/Frontend/assets/91667853/4752442b-b9e3-4351-a701-103b4a7b6aa5">  

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 첨삭 반영 페이지 ( = 첨삭 완료 후 이력서 수정 페이지 )를 작성했습니다.
- 원본 이력서 데이터, 스냅샷 이력서 데이터, 첨삭 코멘트 데이터를 불러와서 `FeedbackCategoryReflectDetails.tsx` 에 데이터를 뿌려줍니다.
- `FeedbackCategoryReflectDetails.tsx` 내부에서 블럭마다 map을 돌리는데, 코멘트가 있는 블럭의 경우 코멘트 데이터를 토글에 감싸 렌더링합니다.
- 코멘트가 달린 블럭을 수정한 경우, 블럭 데이터 중 `reflectFeedback` 값이 true가 됩니다.
  - 이때 원본(스냅샷) 데이터를 함께 보여줍니다.
  - 스냅샷 데이터가 배열의 형태로 되어 있는데, 해당하는 id의 스냅샷 블럭 데이터만 가져와야 해서 `getIndexedSnapshotObject`를 활용해 id로 바로 블럭만 뽑아 불러올 수 있도록 객체로 변환하는 포맷팅 과정을 거쳐줍니다. (코멘트 데이터 뿌려주는 로직과 동일)
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
**files changed 개수가 많아요.. 죄송합니다..**
path parameter로 id가 아니라 resumeId를 사용하는 곳이 많아 이력서 관련해서는 id를 모두 resumeId로 바꿨습니다..
중간에 바꿔야만 다음 작업을 진행할 수 있다고 생각했는데 지금 다시 보니 그런 것도 아니네요 🥹
- 카테고리 type에서 사용해야 하는 타입들이 있어 수정했습니다.

## 🔎 PR포인트 및 궁금한 점
- `useGetSnapshotResume`로 스냅샷 데이터 불러올 때 useSuspenseQuery를 사용하는데도 `FeedbackCategoryReflectDetails.tsx`에서 `getIndexedSnapshotObject`를 돌릴 때 snapshotData가 undefined라 forEach를 못 돌리는 에러가 뜨더라구요. 
레이아웃에 Suspense가 걸려있고 useSuspenseQuery를 사용하는데도 왜 데이터가 undefined를 반환하는지 모르겠습니다. 
혹시 몰라 컴포넌트 내부에 바로 Suspense를 감싸줘봤는데도 그러더라구요!
  - 우선은 그래서 `FeedbackCategoryReflectDetails` 내부에서 snapshotData가 undefined이면 return 시키도록 조건문 추가해줬습니다.
- 변수명.. FeedbackCategoryReflectDetails.. 어떤가요? 기존에 있던 FeedbackCategoryDetails의 확장 버전임을 명시하고 싶어서 Reflect만 추가해줬는데 너무 길긴 하네요..