### PR TITLE
Gmmq 685 feat: 첨삭 뷰어 멘토 정보 가져오기

### DIFF
--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Text, Icon, Image, Tooltip, useDisclosure, Divider } from '@chakra-ui/react';
 import MDEditor from '@uiw/react-md-editor';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { HiPencilAlt, HiTrash } from 'react-icons/hi';
 import { useParams } from 'react-router-dom';
 import { ConfirmModal } from '../ConfirmModal';
@@ -39,12 +39,6 @@ const FeedbackView = ({
   const { mutate: deleteCommentMutate } = useDeleteFeedbackComment(resumeId, eventId);
   const { isOpen, onOpen, onClose } = useDisclosure();
 
-  useEffect(() => {
-    if (content !== '') {
-      setValue(content);
-    }
-  }, [value, content]);
-
   const isEditToggle = () => {
     setIsEdit(!isEdit);
   };
@@ -68,7 +62,7 @@ const FeedbackView = ({
         { resumeId, eventId, commentId, body },
         {
           onSuccess: () => {
-            setValue('');
+            setValue(value);
             isEditToggle();
           },
         },

--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -17,7 +17,7 @@ type FeedbackViewProps = {
   lastModifiedAt?: string;
   commentId?: number;
   isAuthorizedMentor?: boolean;
-  mentorData: ReadMentor;
+  mentorData: Pick<ReadMentor, 'imageUrl' | 'nickname'>;
 };
 
 const LABELS = {

--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -8,6 +8,7 @@ import { FeedbackInput } from '../FeedbackInput';
 import { Label } from '~/components/atoms/Label';
 import useDeleteFeedbackComment from '~/queries/event/useDeleteFeedbackComment';
 import usePatchFeedbackComment from '~/queries/event/usePatchFeedbackComment';
+import { ReadMentor } from '~/types/mentor';
 import { formatKoreanDateWithoutSeconds } from '~/utils/formatDate';
 import '@uiw/react-markdown-preview/markdown.css';
 
@@ -16,6 +17,7 @@ type FeedbackViewProps = {
   lastModifiedAt?: string;
   commentId?: number;
   isAuthorizedMentor?: boolean;
+  mentorData: ReadMentor;
 };
 
 const LABELS = {
@@ -30,6 +32,7 @@ const FeedbackView = ({
   content = ``,
   lastModifiedAt = '2023-11-15 17:17:09',
   commentId,
+  mentorData,
   isAuthorizedMentor = false,
 }: FeedbackViewProps) => {
   const [isEdit, setIsEdit] = useState<boolean>(false);
@@ -37,6 +40,7 @@ const FeedbackView = ({
   const { resumeId = '', eventId = '' } = useParams();
   const { mutate: patchCommentMutate } = usePatchFeedbackComment(resumeId, eventId);
   const { mutate: deleteCommentMutate } = useDeleteFeedbackComment(resumeId, eventId);
+
   const { isOpen, onOpen, onClose } = useDisclosure();
 
   const isEditToggle = () => {
@@ -122,15 +126,15 @@ const FeedbackView = ({
                 py={1}
               >
                 <Tooltip
-                  label={'카키디'}
+                  label={mentorData.nickname}
                   placement="top"
                   hasArrow
                 >
                   <Image
                     borderRadius="full"
                     boxSize="24px"
-                    /* FIXME 멘토 아이콘 */
-                    src="https://bit.ly/dan-abramov"
+                    src={mentorData.imageUrl}
+                    alt="멘토 프로필 이미지"
                   />
                 </Tooltip>
                 <Text
@@ -138,8 +142,7 @@ const FeedbackView = ({
                   fontWeight={'bold'}
                   color={'gray.800'}
                 >
-                  {/* FIXME 멘토 닉네임 */}
-                  카키디
+                  {mentorData.nickname}
                 </Text>
               </Flex>
               {isAuthorizedMentor ? (

--- a/src/components/molecules/FeedbackView/index.stories.tsx
+++ b/src/components/molecules/FeedbackView/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta } from '@storybook/react';
 import FeedbackView from './FeedbackView';
+import { ReadMentor } from '~/types/mentor';
 
 const meta = {
   title: 'Resumeme/Components/FeedbackView',
@@ -9,10 +10,14 @@ const meta = {
 
 export default meta;
 
+const DUMMY_DATA = {
+  imageUrl: 'https://i.pinimg.com/564x/b9/6a/9f/b96a9f10dd4365c867ff8d8972864a01.jpg',
+  nickname: '내가멘토다',
+} as ReadMentor;
 export const Default = () => {
   return (
     <div>
-      <FeedbackView />
+      <FeedbackView mentorData={DUMMY_DATA} />
     </div>
   );
 };

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -7,13 +7,12 @@ import { FeedbackComment } from '~/types/event/feedback';
 import { ReadMentor } from '~/types/mentor';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
-import { User } from '~/types/user';
 import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
 
 type FeedbackCategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
-  mentorData: ReadMentor | User;
+  mentorData: Pick<ReadMentor, 'imageUrl' | 'nickname'>;
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   isAuthorizedMentor?: boolean;
   isFeedbackPage?: boolean;

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -4,6 +4,7 @@ import { BorderBox } from '~/components/atoms/BorderBox';
 import { FeedbackView } from '~/components/molecules/FeedbackView';
 import FeedbackBlock from '~/components/templates/FeedbackResumeTemplate/FeedbackBlock';
 import { FeedbackComment } from '~/types/event/feedback';
+import { ReadMentor } from '~/types/mentor';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
 import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
@@ -11,6 +12,7 @@ import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
 type FeedbackCategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
+  mentorData: ReadMentor;
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   isAuthorizedMentor?: boolean;
   isFeedbackPage?: boolean;
@@ -20,6 +22,7 @@ const FeedbackCategoryDetails = <T extends ReadCategories>({
   arrayData,
   DetailsComponent,
   commentsData,
+  mentorData,
   isAuthorizedMentor = false,
   isFeedbackPage = false,
 }: FeedbackCategoryDetailsProps<T>) => {
@@ -54,6 +57,7 @@ const FeedbackCategoryDetails = <T extends ReadCategories>({
                           lastModifiedAt={currentComment.lastModifiedAt}
                           content={currentComment.content}
                           isAuthorizedMentor={isAuthorizedMentor}
+                          mentorData={mentorData}
                         />
                       ))}
                     </>

--- a/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
+++ b/src/components/organisms/FeedbackCategoryDetails/FeedbackCategoryDetails.tsx
@@ -7,12 +7,13 @@ import { FeedbackComment } from '~/types/event/feedback';
 import { ReadMentor } from '~/types/mentor';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
+import { User } from '~/types/user';
 import { getIndexedCommentsObject } from '~/utils/getIndexedCommentsObject';
 
 type FeedbackCategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
-  mentorData: ReadMentor;
+  mentorData: ReadMentor | User;
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   isAuthorizedMentor?: boolean;
   isFeedbackPage?: boolean;

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -15,7 +15,7 @@ type CategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
   snapshotData: T[];
-  mentorData: ReadMentor;
+  mentorData: Pick<ReadMentor, 'imageUrl' | 'nickname'>;
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   FormComponent?: React.ComponentType<FormComponentProps<T>>;
   isCurrentUser: boolean;

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -5,6 +5,7 @@ import { AccordionToggle } from '~/components/atoms/AccordionToggle';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { FeedbackView } from '~/components/molecules/FeedbackView';
 import { FeedbackComment } from '~/types/event/feedback';
+import { ReadMentor } from '~/types/mentor';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
 import { FormComponentProps } from '~/types/props/formComponentProps';
 import { ReadCategories } from '~/types/resume/categories';
@@ -14,6 +15,7 @@ type CategoryDetailsProps<T extends ReadCategories> = {
   arrayData: T[];
   commentsData: FeedbackComment[];
   snapshotData: T[];
+  mentorData: ReadMentor;
   DetailsComponent: React.ComponentType<DetailsComponentProps<T>>;
   FormComponent?: React.ComponentType<FormComponentProps<T>>;
   isCurrentUser: boolean;
@@ -23,6 +25,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
   arrayData,
   commentsData,
   snapshotData,
+  mentorData,
   DetailsComponent,
   FormComponent,
   isCurrentUser,
@@ -82,6 +85,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                           commentId={currentComment.commentId}
                           lastModifiedAt={currentComment.lastModifiedAt}
                           content={currentComment.content}
+                          mentorData={mentorData}
                         />
                       ))}
                     </>

--- a/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
+++ b/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
@@ -12,6 +12,7 @@ import {
 } from '~/components/organisms/ResumeDetails';
 import { useGetSnapshotResume } from '~/queries/resume/details/useGetSnapshotResume';
 import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
+import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const FeedbackCompleteTemplate = () => {
   const { resumeId = '', eventId = '' } = useParams();
@@ -20,6 +21,7 @@ const FeedbackCompleteTemplate = () => {
   } = useGetResumeFeedbacks({ resumeId, eventId });
 
   const { data: details } = useGetSnapshotResume({ resumeId });
+  const { data: mentorData } = useGetMentorDetail({ mentorId: '1' });
 
   return (
     <Flex
@@ -61,6 +63,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.careers}
                     DetailsComponent={CareerDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}
@@ -78,6 +81,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.projects}
                     DetailsComponent={ProjectDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}
@@ -95,6 +99,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.trainings}
                     DetailsComponent={TrainingDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}
@@ -112,6 +117,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.certifications}
                     DetailsComponent={AwardDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}
@@ -129,6 +135,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.foreignLanguages}
                     DetailsComponent={LanguageDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}
@@ -146,6 +153,7 @@ const FeedbackCompleteTemplate = () => {
                     arrayData={details.activities}
                     DetailsComponent={ActivityDetails}
                     commentsData={commentResponses}
+                    mentorData={mentorData}
                   />
                 </Box>
               )}

--- a/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
+++ b/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
@@ -21,6 +21,7 @@ const FeedbackCompleteTemplate = () => {
   } = useGetResumeFeedbacks({ resumeId, eventId });
 
   const { data: details } = useGetSnapshotResume({ resumeId });
+  /**FIXME - mentorId useGetResumeFeedbacks에서 꺼내오기 */
   const { data: mentorData } = useGetMentorDetail({ mentorId: '1' });
 
   return (

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -28,6 +28,7 @@ import {
 import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
 import { useGetSnapshotResume } from '~/queries/resume/details/useGetSnapshotResume';
 import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
+import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const FeedbackReflectTemplate = () => {
   const { resumeId = '', eventId = '' } = useParams();
@@ -51,6 +52,9 @@ const FeedbackReflectTemplate = () => {
     resumeId,
   });
 
+  /**FIXME - mentorId useGetResumeFeedbacks에서 꺼내오기 */
+  const { data: mentorData } = useGetMentorDetail({ mentorId: '1' });
+
   return (
     <Flex
       width="960px"
@@ -68,6 +72,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.careers}
+          mentorData={mentorData}
         />
       </CategoryContainer>
 
@@ -80,6 +85,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.projects}
+          mentorData={mentorData}
         />
       </CategoryContainer>
 
@@ -92,6 +98,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.certifications}
+          mentorData={mentorData}
         />
       </CategoryContainer>
 
@@ -104,6 +111,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.foreignLanguages}
+          mentorData={mentorData}
         />
       </CategoryContainer>
 
@@ -116,6 +124,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.trainings}
+          mentorData={mentorData}
         />
       </CategoryContainer>
 
@@ -128,6 +137,7 @@ const FeedbackReflectTemplate = () => {
           isCurrentUser={isCurrentUser}
           commentsData={commentResponses}
           snapshotData={snapshotData.activities}
+          mentorData={mentorData}
         />
       </CategoryContainer>
     </Flex>

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackResumeTemplate.tsx
@@ -13,6 +13,7 @@ import {
   ProjectDetails,
   TrainingDetails,
 } from '~/components/organisms/ResumeDetails';
+import useUser from '~/hooks/useUser';
 import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
 import { useGetResumeDetails } from '~/queries/resume/details/useGetResumeDetails';
 import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
@@ -26,6 +27,8 @@ const FeedbackResumeTemplate = () => {
   const {
     data: { commentResponses },
   } = useGetResumeFeedbacks({ resumeId, eventId });
+
+  const { user: mentorData } = useUser();
 
   const data = {
     basic: basicInfo,
@@ -217,6 +220,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={CareerDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}
@@ -236,6 +240,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={ProjectDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}
@@ -255,6 +260,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={TrainingDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}
@@ -274,6 +280,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={AwardDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}
@@ -293,6 +300,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={LanguageDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}
@@ -312,6 +320,7 @@ const FeedbackResumeTemplate = () => {
                     DetailsComponent={ActivityDetails}
                     isAuthorizedMentor
                     isFeedbackPage
+                    mentorData={mentorData!}
                   />
                 </Box>
               )}

--- a/src/types/event/feedback.ts
+++ b/src/types/event/feedback.ts
@@ -8,6 +8,7 @@ type FeedbackComment = {
 type Feedback = {
   commentResponses: FeedbackComment[];
   overallReview: string | null;
+  mentorId: string;
 };
 
 export type { FeedbackComment, Feedback };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="1192" alt="스크린샷 2023-11-24 오후 6 25 01" src="https://github.com/resumeme/Frontend/assets/91667853/28f63655-695e-48b0-9083-a5f3127e5479">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 첨삭 코멘트 뷰 컴포넌트에 멘토 정보를 받아 렌더링하도록 했습니다.
- 첨삭 완료 페이지는 멘티도 조회할 수 있는 페이지라 `mentorId`를 가지고 멘토 정보 조회 api를 한 번 더 호출합니다.
- 첨삭 페이지는 멘토 본인만 조회할 수 있는 페이지라 멘토 정보 조회 api를 호출할 필요 없이 user에 있는 정보를 사용합니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 아직 api에서 코멘트에 mentorId를 주고 있지 않아 임의로 1번 멘토를 불러오고 있습니다. (수정 필요!!)
## 🔎 PR포인트 및 궁금한 점
