### PR TITLE
GMMQ-675 feat: 페이지네이션 후 스크롤 최상단으로 이동

### DIFF
--- a/src/components/molecules/Pagination/Pagination.tsx
+++ b/src/components/molecules/Pagination/Pagination.tsx
@@ -11,7 +11,7 @@ type PaginationProps = {
   total: number;
   size: number;
   page: number;
-  setPage: React.Dispatch<React.SetStateAction<number>>;
+  setPage: (page: number) => void;
 };
 
 const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
@@ -20,6 +20,7 @@ const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
     <Flex
       w={'full'}
       justifyContent={'center'}
+      align={'center'}
       mt={'10rem'}
     >
       <IconButton
@@ -37,15 +38,16 @@ const Pagination = ({ total, size, page, setPage }: PaginationProps) => {
           return (
             <ChakraButton
               key={i + 1}
+              size={'xs'}
               onClick={() => setPage(i + 1)}
-              bg={isCurrentPage ? 'primary.900' : 'none'}
+              bg={isCurrentPage ? 'primary.800' : 'none'}
               _hover={{
-                bg: isCurrentPage ? 'primary.900' : 'primary.100',
+                bg: isCurrentPage ? 'primary.800' : 'primary.100',
               }}
               w={'auto'}
             >
               <Text
-                fontSize={'1.2rem'}
+                fontSize={'1rem'}
                 color={isCurrentPage ? 'gray.100' : 'gray. 700'}
               >
                 {i + 1}

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -9,14 +9,29 @@ const EventGridTemplate = () => {
   const size = 6;
   const { data } = useGetEventList({ page, size });
 
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  const handlePageChange = (newPage: number) => {
+    if (newPage !== page) {
+      setPage(newPage);
+    }
+    scrollToTop();
+  };
+
   return (
     <>
       <Text
-        color={'gray.900'}
+        color={'gray.800'}
         fontSize={'1.5rem'}
+        fontWeight={'semibold'}
         mb={'2rem'}
       >
-        진행 중인 첨삭 이벤트
+        진행 중인 피드백
       </Text>
       {data.events.length ? (
         <>
@@ -24,7 +39,7 @@ const EventGridTemplate = () => {
           <Pagination
             size={size}
             page={page}
-            setPage={setPage}
+            setPage={handlePageChange}
             total={data.pageData.totalElements}
           />
         </>


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 페이지네이션 후 스크롤 최상단으로 이동
- 기존 setPage를 바로 프로퍼티로 넘겨주지 않고 핸들러 함수(handlePageChange)를 만들어서 넣어주었습니다.
- 클릭 페이지와 현재 페이지를 비교 후, 다른 경우에만 setPage를 합니다.
- 페이지네이션 버튼을 누른 경우 무조건 최상단으로 이동합니다.
- 최상단으로 이동할 때 부드럽게 이동하도록 scroll-behavior를 smooth로 주었습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
- 쿼리에서 데이터를 캐싱하지 않은 경우에는 Spinner가 돌아 부드럽게 올라가지 않는 것처럼 보일 수 있습니다.
- 특정 페이지를 처음 간 경우에는 부드럽지 않다가 다시 해당 페이지를 가면 부드럽게 올라옵니다.

## 🔎 PR포인트 및 궁금한 점
