### PR TITLE
Gmmq 623 fix: 이력서 선택 모달 스크롤 생기는 문제 해결

### DIFF
--- a/src/components/organisms/RadioCardGroup/RadioCard.tsx
+++ b/src/components/organisms/RadioCardGroup/RadioCard.tsx
@@ -14,7 +14,10 @@ const RadioCard = ({ children, borderBoxStyle, ...props }: RadioCardProps) => {
 
   return (
     <Box as={'label'}>
-      <input {...inputProps} />
+      <input
+        {...inputProps}
+        style={{ display: 'none' }}
+      />
       <BorderBox
         h={'full'}
         {...radioProps}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

https://github.com/resumeme/Frontend/assets/91667853/d5c612c8-0001-4f39-bc28-8bd079d4a059
### 수정 전 ⬇️
https://github.com/resumeme/Frontend/assets/91667853/7f8da619-ac00-4e04-9828-7ee7eafc653c



## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
이력서 선택 모달의 RadioCardGroup에서 라디오 카드를 선택하면 선택한 라디오카드에 해당하는 input이 아래에 렌더링되어 모달이 위로 움직이는 것처럼 보이는 문제가 있었습니다. (두번째 영상 참고)
input이 라디오버튼 개수만큼 자리를 차지하고 있어 나타나는 문제로 보여 라디오카드의 input에 display: none을 걸어주었습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
