### PR TITLE
Gmmq 692 feat: 이력서 메모 기능 구현

### DIFF
--- a/src/api/resume/create/patchResumeMemo.ts
+++ b/src/api/resume/create/patchResumeMemo.ts
@@ -1,0 +1,28 @@
+import { isAxiosError } from 'axios';
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { ResumeMeErrorResponse } from '~/types/errorResponse';
+import { getCookie } from '~/utils/cookie';
+
+type Memo = {
+  memo: string;
+};
+type PatchResumeMemo = { resumeId: string; resumeMemo: Memo };
+
+export const patchResumeMemo = async ({ resumeId, resumeMemo }: PatchResumeMemo) => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+
+  try {
+    const { data } = await resumeMeAxios.patch(`v2/resumes/${resumeId}`, resumeMemo, {
+      headers: {
+        /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
+        Authorization: accessToken,
+      },
+    });
+    return data;
+  } catch (e) {
+    if (isAxiosError<ResumeMeErrorResponse>(e)) {
+      throw new Error(e.response?.data.message);
+    }
+  }
+};

--- a/src/api/resume/create/patchResumeMemo.ts
+++ b/src/api/resume/create/patchResumeMemo.ts
@@ -1,7 +1,5 @@
-import { isAxiosError } from 'axios';
 import { resumeMeAxios } from '~/api/axios';
 import CONSTANTS from '~/constants';
-import { ResumeMeErrorResponse } from '~/types/errorResponse';
 import { getCookie } from '~/utils/cookie';
 
 type Memo = {
@@ -11,18 +9,10 @@ type PatchResumeMemo = { resumeId: string; resumeMemo: Memo };
 
 export const patchResumeMemo = async ({ resumeId, resumeMemo }: PatchResumeMemo) => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
-
-  try {
-    const { data } = await resumeMeAxios.patch(`v2/resumes/${resumeId}`, resumeMemo, {
-      headers: {
-        /* FIXME - 쿠키 등에 별도 저장된 토큰 가져오기 */
-        Authorization: accessToken,
-      },
-    });
-    return data;
-  } catch (e) {
-    if (isAxiosError<ResumeMeErrorResponse>(e)) {
-      throw new Error(e.response?.data.message);
-    }
-  }
+  const { data } = await resumeMeAxios.patch(`v2/resumes/${resumeId}`, resumeMemo, {
+    headers: {
+      Authorization: accessToken,
+    },
+  });
+  return data;
 };

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Icon, Spacer, Text, useDisclosure } from '@chakra-ui/react';
+import { Box, Flex, FormErrorMessage, Icon, Spacer, Text, useDisclosure } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { MdOutlineArticle } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
@@ -41,9 +41,15 @@ const ResumeItem = ({ resume: { id, modifiedAt, title, memo } }: ResumeItemProps
     const {
       register,
       handleSubmit,
-      getValues,
+      watch,
       formState: { errors },
-    } = useForm<MemoFormType>();
+    } = useForm<MemoFormType>({
+      defaultValues: {
+        memo,
+      },
+    });
+
+    const inputMemo = watch('memo');
 
     const onSubmit: SubmitHandler<MemoFormType> = (body) => {
       patchMemo({ resumeId: String(id), resumeMemo: body });
@@ -56,44 +62,43 @@ const ResumeItem = ({ resume: { id, modifiedAt, title, memo } }: ResumeItemProps
         onClose={onClose}
       >
         <form onSubmit={handleSubmit(onSubmit)}>
-          <Flex
-            direction={'column'}
-            w="full"
-            gap={3}
-          >
+          <FormControl isInvalid={Boolean(errors.memo)}>
             <Flex
-              w={'full'}
               direction={'column'}
+              w="full"
+              position={'relative'}
+              gap={2}
             >
               <FormLabel>메모하기</FormLabel>
-              <FormControl isInvalid={Boolean(errors.memo)}>
-                <FormTextInput
-                  placeholder="40자 이내로 간략하게 작성해주세요."
-                  id="memo"
-                  fontSize={'sm'}
-                  color={'gray.700'}
-                  defaultValue={memo}
-                  register={{
-                    ...register('memo', {
-                      maxLength: {
-                        value: 41,
-                        message: `40자 이내로 입력해주세요. (${getValues('memo')?.length}/40자)`,
-                      },
-                    }),
-                  }}
-                  error={errors.memo}
-                />
-              </FormControl>
+              <FormTextInput
+                placeholder="40자 이내로 간략하게 작성해주세요."
+                id="memo"
+                fontSize={'sm'}
+                color={'gray.700'}
+                defaultValue={memo}
+                autoComplete="off"
+                register={{
+                  ...register('memo', {
+                    maxLength: {
+                      value: 40,
+                      message: `40자 이내로 작성해주세요.`,
+                    },
+                  }),
+                }}
+              />
+              <FormErrorMessage>
+                {errors.memo && `${errors.memo.message} (${inputMemo?.length})`}
+              </FormErrorMessage>
+              <Flex justify={'end'}>
+                <Button
+                  size={'xs'}
+                  type="submit"
+                >
+                  저장
+                </Button>
+              </Flex>
             </Flex>
-            <Flex justify={'end'}>
-              <Button
-                size={'xs'}
-                type="submit"
-              >
-                저장
-              </Button>
-            </Flex>
-          </Flex>
+          </FormControl>
         </form>
       </Modal>
     );

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -1,8 +1,15 @@
-import { Flex, Icon, Input, Spacer, Text } from '@chakra-ui/react';
+import { Box, Flex, Icon, Spacer, Text, useDisclosure } from '@chakra-ui/react';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import { MdOutlineArticle } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
+import { Button } from '~/components/atoms/Button';
+import { FormLabel } from '~/components/atoms/FormLabel';
+import { FormControl } from '~/components/molecules/FormControl';
+import { FormTextInput } from '~/components/molecules/FormTextInput';
+import { Modal } from '~/components/molecules/Modal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { appPaths } from '~/config/paths';
+import { usePatchResumeMemo } from '~/queries/resume/create/usePatchResumeMemo';
 import { useDeleteResume } from '~/queries/resume/delete/useDeleteResume';
 import { MyResume } from '~/types/resume/resumeListItem';
 import { formatDate } from '~/utils/formatDate';
@@ -11,10 +18,16 @@ type ResumeItemProps = {
   resume: MyResume;
 };
 
-const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
-  const navigate = useNavigate();
+type MemoFormType = {
+  memo: string;
+};
 
+const ResumeItem = ({ resume: { id, modifiedAt, title, memo } }: ResumeItemProps) => {
+  const navigate = useNavigate();
   const { mutate: deleteResume } = useDeleteResume();
+  const { mutate: patchMemo } = usePatchResumeMemo();
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const HandleEdit = () => {
     navigate(appPaths.resumeEdit(id));
@@ -22,6 +35,68 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
 
   const HandleDelete = () => {
     deleteResume({ resumeId: String(id) });
+  };
+
+  const MemoModal = () => {
+    const {
+      register,
+      handleSubmit,
+      getValues,
+      formState: { errors },
+    } = useForm<MemoFormType>();
+
+    const onSubmit: SubmitHandler<MemoFormType> = (body) => {
+      patchMemo({ resumeId: String(id), resumeMemo: body });
+      onClose();
+    };
+
+    return (
+      <Modal
+        isOpen={isOpen}
+        onClose={onClose}
+      >
+        <form onSubmit={handleSubmit(onSubmit)}>
+          <Flex
+            direction={'column'}
+            w="full"
+            gap={3}
+          >
+            <Flex
+              w={'full'}
+              direction={'column'}
+            >
+              <FormLabel>메모하기</FormLabel>
+              <FormControl isInvalid={Boolean(errors.memo)}>
+                <FormTextInput
+                  placeholder="40자 이내로 간략하게 작성해주세요."
+                  id="memo"
+                  fontSize={'sm'}
+                  color={'gray.700'}
+                  defaultValue={memo}
+                  register={{
+                    ...register('memo', {
+                      maxLength: {
+                        value: 41,
+                        message: `40자 이내로 입력해주세요. (${getValues('memo')?.length}/40자)`,
+                      },
+                    }),
+                  }}
+                  error={errors.memo}
+                />
+              </FormControl>
+            </Flex>
+            <Flex justify={'end'}>
+              <Button
+                size={'xs'}
+                type="submit"
+              >
+                저장
+              </Button>
+            </Flex>
+          </Flex>
+        </form>
+      </Modal>
+    );
   };
 
   return (
@@ -51,30 +126,41 @@ const ResumeItem = ({ resume: { id, modifiedAt, title } }: ResumeItemProps) => {
           {title}
         </Text>
       </Link>
-      <Flex
-        mt={'1.75rem'}
-        borderRadius={'0.3125rem'}
-        p={'0.75rem 1rem'}
-        bg={'gray.200'}
-        alignItems={'center'}
-        w={'full'}
-        gap={'0.69rem'}
+      <Box
+        cursor={'pointer'}
+        onClick={onOpen}
       >
-        <Icon
-          as={MdOutlineArticle}
-          color={'gray.500'}
-          w={'1.25rem'}
-        />
-        <Input
-          isTruncated
-          flexShrink={1}
-          h={'min-content'}
-          p={0}
-          m={0}
-          border={0}
-          placeholder="이력서에 대한 간단한 메모를 남겨보세요. ex) 12월 25일 제출 전까지 피드백 받기"
-        />
-      </Flex>
+        <Flex
+          mt={'1rem'}
+          borderRadius={'0.3125rem'}
+          p={'0.5rem 0.75rem'}
+          bg={'gray.200'}
+          alignItems={'center'}
+          w={'full'}
+          gap={'0.69rem'}
+        >
+          <Icon
+            as={MdOutlineArticle}
+            color={'gray.500'}
+            w={'1.25rem'}
+          />
+          <Text
+            isTruncated
+            flexShrink={1}
+            h={'min-content'}
+            p={0}
+            m={0}
+            border={0}
+            color={'gray.400'}
+            fontSize={'sm'}
+          >
+            {memo
+              ? memo
+              : '이력서에 대한 간단한 메모를 남겨보세요. ex. 12월 25일 제출 전까지 피드백 받기'}
+          </Text>
+        </Flex>
+      </Box>
+      <MemoModal />
     </>
   );
 };

--- a/src/queries/resume/create/usePatchResumeMemo.ts
+++ b/src/queries/resume/create/usePatchResumeMemo.ts
@@ -17,11 +17,5 @@ export const usePatchResumeMemo = () => {
       });
       queryClient.refetchQueries({ queryKey: resumesKeys.my() });
     },
-    onError: (error) => {
-      toast({
-        description: error.message,
-        status: 'error',
-      });
-    },
   });
 };

--- a/src/queries/resume/create/usePatchResumeMemo.ts
+++ b/src/queries/resume/create/usePatchResumeMemo.ts
@@ -1,0 +1,27 @@
+import { useToast } from '@chakra-ui/react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { resumesKeys } from '../useGetMyResumes';
+import { patchResumeMemo } from '~/api/resume/create/patchResumeMemo';
+
+export const usePatchResumeMemo = () => {
+  const toast = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationKey: ['patchResumeMemo'],
+    mutationFn: patchResumeMemo,
+    onSuccess: () => {
+      toast({
+        description: '메모가 저장되었어요 :)',
+        status: 'success',
+      });
+      queryClient.refetchQueries({ queryKey: resumesKeys.my() });
+    },
+    onError: (error) => {
+      toast({
+        description: error.message,
+        status: 'error',
+      });
+    },
+  });
+};

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -5,6 +5,7 @@ type ResumeListItem = {
   id: number;
   title: string;
   modifiedAt: string;
+  memo?: string;
 };
 
 type MyResume = ResumeListItem & {


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![Screenshot 2023-11-25 at 23 45 20-memo](https://github.com/resumeme/Frontend/assets/74141521/5fc21885-05ce-432e-865d-0b9feb2c4442)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 메모 기능
- 이력서 관리 탭에서 본인의 이력서 아래에 메모를 추가할 수 있습니다.
- 메모 박스를 클릭할 경우, 메모를 입력하는 모달 창이 뜹니다.
- 기본값(기존에 저장된 값이 null이거나 빈 문자열일 경우)이 없으면 `이력서에 대한 간단한 메모를 남겨보세요. ex. 12월 25일 제출 전까지 피드백 받기` 라는 문자열이 렌더링됩니다.
- 메모 입력 문자열 길이를 에러 메시지와 함께 렌더링합니다.

### 스타일 수정
- 박스 크기와 메모 폰트 크기를 줄였습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
