### PR TITLE
Gmmq 707 feat: 이벤트 수정 페이지 생성, event detail template 수정

### DIFF
--- a/src/api/event/create/patchEventDetail.ts
+++ b/src/api/event/create/patchEventDetail.ts
@@ -1,0 +1,28 @@
+import { resumeMeAxios } from '~/api/axios';
+import CONSTANTS from '~/constants';
+import { CreateEvent } from '~/types/event/event';
+import { getCookie } from '~/utils/cookie';
+
+type PatchEventDetail = {
+  eventId: string;
+  data: CreateEvent;
+};
+
+const patchEventDetail = async ({ data, eventId }: PatchEventDetail): Promise<{ id: number }> => {
+  const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+  data.time.now = new Date().toISOString().substring(0, 16);
+  data.time.endDate = new Date(data.time.endDate).toISOString().substring(0, 16);
+
+  const { data: resEventId } = await resumeMeAxios.patch(
+    `/v1/events/${eventId}`,
+    { ...data },
+    {
+      headers: {
+        [CONSTANTS.ACCESS_TOKEN_HEADER]: accessToken,
+      },
+    },
+  );
+
+  return resEventId;
+};
+export default patchEventDetail;

--- a/src/api/event/postCreateEvent.ts
+++ b/src/api/event/postCreateEvent.ts
@@ -1,4 +1,4 @@
-import { resumeMeAxios } from '../axios';
+import { resumeMeAxios } from '~/api/axios';
 import CONSTANTS from '~/constants';
 import { CreateEvent } from '~/types/event/event';
 import { getCookie } from '~/utils/cookie';

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -175,13 +175,6 @@ const CreateEventTemplate = () => {
           <Button
             size={'md'}
             isLoading={isPending}
-            type="button"
-          >
-            미리보기
-          </Button>
-          <Button
-            size={'md'}
-            isLoading={isPending}
             type="submit"
           >
             등록하기

--- a/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
+++ b/src/components/templates/CreateEventTemplate/CreateEventTemplate.tsx
@@ -10,11 +10,25 @@ import { FormDateInput } from '~/components/molecules/FormDateInput';
 import FormTextInput from '~/components/molecules/FormTextInput/FormTextInput';
 import { LabelCheckboxGroup } from '~/components/molecules/LabelCheckboxGroup';
 import { TermInput } from '~/components/molecules/TermInput';
+import { usePatchEventDetail } from '~/queries/event/create/usePatchEventDetai';
 import { usePostCreateEvent } from '~/queries/usePostCreateEvent';
 import { CreateEvent } from '~/types/event/event';
 
-const CreateEventTemplate = () => {
-  const { mutate: createEvent, isPending } = usePostCreateEvent();
+type CreateEventTemplateProps = {
+  isEdit?: boolean;
+  defaultValues?: CreateEvent;
+  eventId?: string;
+};
+
+const CreateEventTemplate = ({
+  eventId = '',
+  defaultValues,
+  isEdit = false,
+}: CreateEventTemplateProps) => {
+  const { mutate: createEvent, isPending: isCreatePending } = usePostCreateEvent();
+  const { mutate: patchEvent, isPending: isEditPending } = usePatchEventDetail();
+
+  const isPending = isEdit ? isEditPending : isCreatePending;
 
   const [isOpenDateDisabled, setIsOpenDateDisabled] = useState(false);
 
@@ -24,12 +38,16 @@ const CreateEventTemplate = () => {
     handleSubmit,
     register,
     formState: { errors },
-  } = useForm<CreateEvent>();
+  } = useForm<CreateEvent>({ defaultValues });
 
   const closeDateTime = useWatch({ name: 'time.closeDateTime', control });
 
   const onSubmit: SubmitHandler<CreateEvent> = (values) => {
-    createEvent(values);
+    if (isEdit) {
+      patchEvent({ data: values, eventId });
+    } else {
+      createEvent(values);
+    }
   };
 
   return (
@@ -108,7 +126,7 @@ const CreateEventTemplate = () => {
             <HStack spacing={'1.6rem'}>
               <FormLabel isRequired={true}>신청 기간</FormLabel>
               <TermInput<CreateEvent>
-                future
+                future={!isEdit}
                 control={control}
                 includeTime={true}
                 errors={errors}
@@ -177,7 +195,7 @@ const CreateEventTemplate = () => {
             isLoading={isPending}
             type="submit"
           >
-            등록하기
+            {isEdit ? '수정하기' : '등록하기'}
           </Button>
         </Flex>
       </form>

--- a/src/pages/EventPages/EditEventPage/EditEventPage.tsx
+++ b/src/pages/EventPages/EditEventPage/EditEventPage.tsx
@@ -1,0 +1,28 @@
+import { useParams } from 'react-router-dom';
+import { CreateEventTemplate } from '~/components/templates/CreateEventTemplate';
+import { useGetEventDetail } from '~/queries/event/details/useGetEventDetail';
+import { CreateEvent } from '~/types/event/event';
+
+const EditEventPage = () => {
+  const { eventId = '' } = useParams();
+
+  const {
+    data: { content, maximumCount, positions, timeInfo, title },
+  } = useGetEventDetail({ eventId });
+
+  const defaultValues = {
+    info: { content, maximumAttendee: maximumCount, title },
+    positions,
+    time: { ...timeInfo, endDate: timeInfo.endDate.slice(0, 10) },
+  } as CreateEvent;
+
+  return (
+    <CreateEventTemplate
+      eventId={eventId}
+      isEdit
+      defaultValues={defaultValues}
+    />
+  );
+};
+
+export default EditEventPage;

--- a/src/queries/event/create/usePatchEventDetai.ts
+++ b/src/queries/event/create/usePatchEventDetai.ts
@@ -1,0 +1,15 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+import patchEventDetail from '~/api/event/create/patchEventDetail';
+import { appPaths } from '~/config/paths';
+
+export const usePatchEventDetail = () => {
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: patchEventDetail,
+    onSuccess: ({ id }) => {
+      navigate(appPaths.eventDetail(id), { replace: true });
+    },
+  });
+};

--- a/src/routes/router.tsx
+++ b/src/routes/router.tsx
@@ -6,6 +6,7 @@ import Layout from './Layout';
 import MainLayout from './MainLayout';
 import AdminPage from '~/pages/AdminPage/AdminPage';
 import { CreateEventPage } from '~/pages/EventPages/CreateEventPage';
+import EditEventPage from '~/pages/EventPages/EditEventPage/EditEventPage';
 import { EventDetailPage } from '~/pages/EventPages/EventDetailPage';
 import { EventListPage } from '~/pages/EventPages/EventListPage';
 import MainPage from '~/pages/MainPage/MainPage';
@@ -49,6 +50,7 @@ const router = createBrowserRouter([
           { path: 'write-review', element: <WriteReviewPage /> },
 
           { path: 'event/create', element: <CreateEventPage /> },
+          { path: 'event/edit/:eventId', element: <EditEventPage /> },
           { path: 'event/', element: <EventListPage /> },
           { path: 'event/view/:id', element: <EventDetailPage /> },
 


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
이벤트 수정 페이지를 따로 구분했습니다.
이벤트 수정 api를 생성했습니다.
event detail template를 활용할 수 있도록 변경했습니다.
이벤트 상세 페이지의 미리보기 버튼을 제거했습니다.
이벤트 수정 페이지 경로를 추가했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
