### PR TITLE
Gmmq 715 fix: 이벤트 생성 시간 현재시간으로 포맷팅

### DIFF
--- a/src/api/event/postCreateEvent.ts
+++ b/src/api/event/postCreateEvent.ts
@@ -6,14 +6,9 @@ import { getCookie } from '~/utils/cookie';
 const postCreateEvent = async (data: CreateEvent): Promise<{ id: number }> => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
 
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-  const hour = String(date.getHours()).padStart(2, '0');
-  const minute = String(date.getMinutes()).padStart(2, '0');
+  const offset = new Date().getTimezoneOffset() * 60000;
 
-  const formattedDate = `${year}-${month}-${day}T${hour}:${minute}`;
+  const formattedDate = new Date(Date.now() - offset).toISOString().substring(0, 16);
 
   data.time.now = formattedDate;
   data.time.endDate = new Date(data.time.endDate).toISOString().substring(0, 16);

--- a/src/api/event/postCreateEvent.ts
+++ b/src/api/event/postCreateEvent.ts
@@ -5,7 +5,17 @@ import { getCookie } from '~/utils/cookie';
 
 const postCreateEvent = async (data: CreateEvent): Promise<{ id: number }> => {
   const accessToken = getCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
-  data.time.now = new Date().toISOString().substring(0, 16);
+
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  const hour = String(date.getHours()).padStart(2, '0');
+  const minute = String(date.getMinutes()).padStart(2, '0');
+
+  const formattedDate = `${year}-${month}-${day}T${hour}:${minute}`;
+
+  data.time.now = formattedDate;
   data.time.endDate = new Date(data.time.endDate).toISOString().substring(0, 16);
 
   const { data: eventId } = await resumeMeAxios.post(


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
이벤트 생성 시간을 UTC 시간으로 보내고 있어서 해당 부분을 수정했습니다. 

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->
UTC시간에 9시간 더해진 시간이 한국 시간이라서 offset을 통해 그 시간 만큼 빼주는 거라고 합니다
처음에는 하나하나 바꿔주는 형식으로 했는데 찾아보니 오프셋을 이용해서 시간 차이만큼 빼주는 간단한 방법이 있더라고요 허허


## 🔎 PR포인트 및 궁금한 점
toISOstring()은 왜 우리나라 시간으로 안바꿔주고 끝에 z가 붙어있는 UTC 시간으로 바꿔줄까요..
