### PR TITLE
Gmmq 718 style: 메인 페이지 푸터 아래 고정

### DIFF
--- a/src/routes/MainLayout.tsx
+++ b/src/routes/MainLayout.tsx
@@ -26,9 +26,11 @@ const MainLayout = () => {
       >
         <Header />
       </Box>
-      <Suspense fallback={<Spinner />}>
-        <Outlet />
-      </Suspense>
+      <Box flexGrow={1}>
+        <Suspense fallback={<Spinner />}>
+          <Outlet />
+        </Suspense>
+      </Box>
       <Box
         flexGrow={0}
         flexShrink={0}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/3d138677-0132-4a4b-8729-2bd74b01f57e)

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
 메인 페이지에서도 푸터가 아래에 고정될 수 있게 수정했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
