### PR TITLE
Gmmq 721 fix: 첨삭 반영 페이지 블럭 삭제해도 토글 띄우기, 코멘트 스냅샷 데이터로 변경

### DIFF
--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -1,12 +1,9 @@
 import { Divider, Box, Text } from '@chakra-ui/react';
-import { useQueryClient } from '@tanstack/react-query';
 import React from 'react';
 import { useState } from 'react';
-import { useParams } from 'react-router-dom';
 import { AccordionToggle } from '~/components/atoms/AccordionToggle';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { FeedbackView } from '~/components/molecules/FeedbackView';
-import { feedbackKeys } from '~/queries/resume/feedback/feedbackKeys.const';
 import { FeedbackComment } from '~/types/event/feedback';
 import { ReadMentor } from '~/types/mentor';
 import { DetailsComponentProps } from '~/types/props/detailsComponentProps';
@@ -33,53 +30,50 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
   FormComponent,
   isCurrentUser,
 }: CategoryDetailsProps<T>) => {
-  const { resumeId = '', eventId = '' } = useParams();
   const [editTargetIndex, setEditTargetIndex] = useState<number | null>(null);
   const indexedComments = getIndexedCommentsObject(commentsData);
-  const indexedSnapshots = getIndexedSnapshotObject(snapshotData);
-  const queryClient = useQueryClient();
+  const indexedDetails = getIndexedDetails(arrayData);
   return (
     <>
-      {arrayData?.length > 0 && (
+      {snapshotData?.length > 0 && (
         <BorderBox variant={'wide'}>
-          {arrayData.map((data: T, index: number) => {
-            const currentBlockId = data.componentId;
-            const currentComments: FeedbackComment[] = indexedComments[currentBlockId];
-            const currentSnapshots = indexedSnapshots[data.originComponentId!];
-            const isReflectFeedback = data.originComponentId !== data.componentId;
+          {snapshotData.map((snapshotItem: T, index: number) => {
+            const currentComponentId = snapshotItem.componentId;
+            const currentDetail = indexedDetails[snapshotItem.originComponentId!];
+            const currentComments: FeedbackComment[] = indexedComments[snapshotItem.componentId];
+            const isReflectFeedback = currentComponentId !== currentDetail?.componentId;
             const isOpen = currentComments && !isReflectFeedback;
             return (
               <React.Fragment key={index}>
-                {editTargetIndex === index && FormComponent ? (
-                  <FormComponent
-                    defaultValues={{
-                      ...data,
-                      componentId: undefined,
-                      reflectFeedback: undefined,
-                      type: undefined,
-                      originComponentId: undefined,
-                      createdDate: undefined,
-                    }}
-                    isEdit
-                    blockId={data.componentId}
-                    quitEdit={() => {
-                      queryClient.refetchQueries({
-                        queryKey: feedbackKeys.resumeFeedbacks(resumeId, eventId),
-                      });
-                      setEditTargetIndex(null);
-                    }}
-                  />
-                ) : (
-                  <Box
-                    position={'relative'}
-                    role="group"
-                  >
-                    <DetailsComponent
-                      data={data}
-                      onEdit={() => setEditTargetIndex(index)}
-                      isCurrentUser={isCurrentUser}
-                    />
-                  </Box>
+                {currentDetail && (
+                  <>
+                    {editTargetIndex === index && FormComponent ? (
+                      <FormComponent
+                        defaultValues={{
+                          ...currentDetail,
+                          componentId: undefined,
+                          reflectFeedback: undefined,
+                          type: undefined,
+                          originComponentId: undefined,
+                          createdDate: undefined,
+                        }}
+                        isEdit
+                        blockId={currentDetail.componentId}
+                        quitEdit={() => setEditTargetIndex(null)}
+                      />
+                    ) : (
+                      <Box
+                        position={'relative'}
+                        role="group"
+                      >
+                        <DetailsComponent
+                          data={currentDetail}
+                          onEdit={() => setEditTargetIndex(index)}
+                          isCurrentUser={isCurrentUser}
+                        />
+                      </Box>
+                    )}
+                  </>
                 )}
                 {currentComments && (
                   <AccordionToggle
@@ -98,10 +92,10 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                         />
                       ))}
                     </>
-                    {isReflectFeedback && currentSnapshots && (
+                    {isReflectFeedback && (
                       <SnapshotSection>
                         <DetailsComponent
-                          data={currentSnapshots}
+                          data={snapshotItem}
                           isCurrentUser={false}
                         />
                       </SnapshotSection>
@@ -125,12 +119,12 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
 
 export default FeedbackCategoryReflectDetails;
 
-const getIndexedSnapshotObject = <T extends ReadCategories>(snapshotData: T[]) => {
-  const indexedSnapshot: { [blockId: string]: T } = {};
-  snapshotData.forEach((snapshotBlock) => {
-    indexedSnapshot[snapshotBlock.originComponentId!] = snapshotBlock;
+const getIndexedDetails = <T extends ReadCategories>(arrayData: T[]) => {
+  const indexedDetails: { [blockId: string]: T } = {};
+  arrayData.forEach((detailItem) => {
+    indexedDetails[detailItem.originComponentId!] = detailItem;
   });
-  return indexedSnapshot;
+  return indexedDetails;
 };
 
 const SnapshotSection = ({ children }: { children: React.ReactNode }) => {

--- a/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
+++ b/src/components/organisms/FeedbackCateogryReflectDetails/FeedbackCategoryReflectDetails.tsx
@@ -102,7 +102,7 @@ const FeedbackCategoryReflectDetails = <T extends ReadCategories>({
                     )}
                   </AccordionToggle>
                 )}
-                {index !== arrayData.length - 1 && (
+                {index !== snapshotData.length - 1 && (
                   <Divider
                     my={'3rem'}
                     borderColor={'gray.300'}

--- a/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
+++ b/src/components/templates/FeedbackCompleteTemplate/FeedbackCompleteTemplate.tsx
@@ -11,18 +11,17 @@ import {
   TrainingDetails,
 } from '~/components/organisms/ResumeDetails';
 import { useGetSnapshotResume } from '~/queries/resume/details/useGetSnapshotResume';
-import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
+import { useGetFeedbacksSnapshot } from '~/queries/resume/feedback/useGetFeedbacksSnapshot';
 import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const FeedbackCompleteTemplate = () => {
-  const { resumeId = '', eventId = '' } = useParams();
+  const { resumeId = '' } = useParams();
   const {
-    data: { commentResponses, overallReview },
-  } = useGetResumeFeedbacks({ resumeId, eventId });
+    data: { commentResponses, overallReview, mentorId },
+  } = useGetFeedbacksSnapshot({ resumeId });
 
   const { data: details } = useGetSnapshotResume({ resumeId });
-  /**FIXME - mentorId useGetResumeFeedbacks에서 꺼내오기 */
-  const { data: mentorData } = useGetMentorDetail({ mentorId: '1' });
+  const { data: mentorData } = useGetMentorDetail({ mentorId });
 
   return (
     <Flex

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -29,12 +29,12 @@ import {
 } from '~/queries/resume/details';
 import { useGetResumeBasic } from '~/queries/resume/details/useGetResumeBasic';
 import { useGetSnapshotResume } from '~/queries/resume/details/useGetSnapshotResume';
-import { useGetResumeFeedbacks } from '~/queries/resume/feedback/useGetResumeFeedbacks';
+import { useGetFeedbacksSnapshot } from '~/queries/resume/feedback/useGetFeedbacksSnapshot';
 import { usePatchFeedbackReflectComplete } from '~/queries/resume/feedback/usePatchFeedbackReflectComplete';
 import { useGetMentorDetail } from '~/queries/user/details/useGetMentorDetail';
 
 const FeedbackReflectTemplate = () => {
-  const { resumeId = '', eventId = '' } = useParams();
+  const { resumeId = '' } = useParams();
   const { data: basicInfo } = useGetResumeBasic({ resumeId });
   const { data: careersData } = useGetResumeCareer({ resumeId });
   const { data: trainingsData } = useGetResumeTraining({ resumeId });
@@ -49,7 +49,7 @@ const FeedbackReflectTemplate = () => {
 
   const {
     data: { commentResponses },
-  } = useGetResumeFeedbacks({ resumeId, eventId });
+  } = useGetFeedbacksSnapshot({ resumeId });
 
   const { data: snapshotData } = useGetSnapshotResume({
     resumeId,


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
현재 코멘트가 달린 블럭을 삭제한 경우 아래의 모습과 같이 뜹니다! UI적인 부분을 좀 다듬어야 할 것 같아요.
<img width="1025" alt="스크린샷 2023-11-27 오후 11 54 01" src="https://github.com/resumeme/Frontend/assets/91667853/51f1c86a-9214-43e5-98a9-a73855020967">

<img width="1004" alt="스크린샷 2023-11-27 오후 11 54 09" src="https://github.com/resumeme/Frontend/assets/91667853/2cf571a7-4d42-4114-b084-585de6c84425">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이제는 api에서 첨삭 코멘트도 스냅샷 id를 주고 있어 스냅샷 코멘트 조회 api함수를 새로 작성했습니다!
  - 스냅샷 데이터를 사용하는 곳 (`첨삭 반영 페이지`, `첨삭 완료 페이지`)에서는 스냅샷 코멘트 api를 사용하도록 수정했습니다.
- 추가로 첨삭 반영 페이지에서 기존에는 복사본 데이터로 map을 돌리던 구조를 스냅샷 데이터로 map을 돌리도록 수정했습니다.
  - 따라서 블럭을 **삭제**하더라도 `첨삭 코멘트`와 `스냅샷 데이터`를 조회할 수 있습니다. (스크린샷 참고)
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
