### PR TITLE
Gmmq 736 feat: 이력서 선택 모달에서 희망직무, 메모 띄우기

### DIFF
--- a/src/components/molecules/MemoBox/MemoBox.tsx
+++ b/src/components/molecules/MemoBox/MemoBox.tsx
@@ -2,7 +2,7 @@ import { Box, Flex, Text, Icon } from '@chakra-ui/react';
 import { MdOutlineArticle } from 'react-icons/md';
 
 type MemoBoxProps = {
-  onOpen: () => void;
+  onOpen?: () => void;
   memo?: string;
 };
 

--- a/src/components/molecules/MemoBox/MemoBox.tsx
+++ b/src/components/molecules/MemoBox/MemoBox.tsx
@@ -1,0 +1,48 @@
+import { Box, Flex, Text, Icon } from '@chakra-ui/react';
+import { MdOutlineArticle } from 'react-icons/md';
+
+type MemoBoxProps = {
+  onOpen: () => void;
+  memo?: string;
+};
+
+const MemoBox = ({ onOpen, memo }: MemoBoxProps) => {
+  return (
+    <Box
+      cursor={'pointer'}
+      onClick={onOpen}
+    >
+      <Flex
+        mt={'1rem'}
+        borderRadius={'0.3125rem'}
+        p={'0.5rem 0.75rem'}
+        bg={'gray.200'}
+        alignItems={'center'}
+        w={'full'}
+        gap={'0.69rem'}
+      >
+        <Icon
+          as={MdOutlineArticle}
+          color={'gray.500'}
+          w={'1.25rem'}
+        />
+        <Text
+          isTruncated
+          flexShrink={1}
+          h={'min-content'}
+          p={0}
+          m={0}
+          border={0}
+          color={'gray.400'}
+          fontSize={'sm'}
+        >
+          {memo
+            ? memo
+            : '이력서에 대한 간단한 메모를 남겨보세요. ex. 12월 25일 제출 전까지 피드백 받기'}
+        </Text>
+      </Flex>
+    </Box>
+  );
+};
+
+export default MemoBox;

--- a/src/components/molecules/MemoBox/index.stories.tsx
+++ b/src/components/molecules/MemoBox/index.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta } from '@storybook/react';
+import MemoBox from './MemoBox';
+
+const meta: Meta = {
+  title: 'Resumeme/Components/MemoBox',
+  component: MemoBox,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+export const Default = () => {
+  return <MemoBox onOpen={() => {}} />;
+};

--- a/src/components/molecules/MemoBox/index.ts
+++ b/src/components/molecules/MemoBox/index.ts
@@ -1,0 +1,1 @@
+export { default as MemoBox } from './MemoBox';

--- a/src/components/molecules/ResumeListItem/ResumeListItem.tsx
+++ b/src/components/molecules/ResumeListItem/ResumeListItem.tsx
@@ -1,12 +1,13 @@
 import { Box, Flex, Text } from '@chakra-ui/react';
 import { Label } from '~/components/atoms/Label';
+import { MemoBox } from '~/components/molecules/MemoBox';
 import { ResumeListItem } from '~/types/resume/resumeListItem';
 
 type ResumeListItemProps = {
   data: ResumeListItem;
 };
 
-const ResumeListItem = ({ data: { title, modifiedAt, position } }: ResumeListItemProps) => {
+const ResumeListItem = ({ data: { title, modifiedAt, position, memo } }: ResumeListItemProps) => {
   return (
     <Box>
       <Flex direction={'column'}>
@@ -33,6 +34,7 @@ const ResumeListItem = ({ data: { title, modifiedAt, position } }: ResumeListIte
           {title}
         </Text>
         {/**TODO - 메모 컴포넌트 */}
+        {memo && <MemoBox memo={memo} />}
       </Flex>
     </Box>
   );

--- a/src/components/molecules/ResumeListItem/ResumeListItem.tsx
+++ b/src/components/molecules/ResumeListItem/ResumeListItem.tsx
@@ -6,7 +6,7 @@ type ResumeListItemProps = {
   data: ResumeListItem;
 };
 
-const ResumeListItem = ({ data: { title, modifiedAt } }: ResumeListItemProps) => {
+const ResumeListItem = ({ data: { title, modifiedAt, position } }: ResumeListItemProps) => {
   return (
     <Box>
       <Flex direction={'column'}>
@@ -17,13 +17,14 @@ const ResumeListItem = ({ data: { title, modifiedAt } }: ResumeListItemProps) =>
           >
             {new Date(modifiedAt).toLocaleString()}
           </Text>
-          {/**FIXME - 이력서 희망 직무 api 데이터 추가되면 대체하기 */}
-          <Label
-            bg={'gray.300'}
-            color={'gray.700'}
-          >
-            {'이력서 희망 직무'}
-          </Label>
+          {position && (
+            <Label
+              bg={'gray.300'}
+              color={'gray.700'}
+            >
+              {position}
+            </Label>
+          )}
         </Flex>
         <Text
           fontSize={'1.125rem'}

--- a/src/components/molecules/ResumeListItem/index.stories.tsx
+++ b/src/components/molecules/ResumeListItem/index.stories.tsx
@@ -16,6 +16,8 @@ export const Default = () => {
         id: 1,
         title: 'title1',
         modifiedAt: '2023-11-17',
+        position: '프론트엔드',
+        memo: '메모임!',
       }}
     />
   );

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -1,11 +1,11 @@
-import { Box, Flex, FormErrorMessage, Icon, Spacer, Text, useDisclosure } from '@chakra-ui/react';
+import { Flex, FormErrorMessage, Spacer, Text, useDisclosure } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
-import { MdOutlineArticle } from 'react-icons/md';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 import { FormLabel } from '~/components/atoms/FormLabel';
 import { FormControl } from '~/components/molecules/FormControl';
 import { FormTextInput } from '~/components/molecules/FormTextInput';
+import { MemoBox } from '~/components/molecules/MemoBox';
 import { Modal } from '~/components/molecules/Modal';
 import { EditDeleteOptionsButton } from '~/components/molecules/OptionsButton';
 import { appPaths } from '~/config/paths';
@@ -131,40 +131,10 @@ const ResumeItem = ({ resume: { id, modifiedAt, title, memo } }: ResumeItemProps
           {title}
         </Text>
       </Link>
-      <Box
-        cursor={'pointer'}
-        onClick={onOpen}
-      >
-        <Flex
-          mt={'1rem'}
-          borderRadius={'0.3125rem'}
-          p={'0.5rem 0.75rem'}
-          bg={'gray.200'}
-          alignItems={'center'}
-          w={'full'}
-          gap={'0.69rem'}
-        >
-          <Icon
-            as={MdOutlineArticle}
-            color={'gray.500'}
-            w={'1.25rem'}
-          />
-          <Text
-            isTruncated
-            flexShrink={1}
-            h={'min-content'}
-            p={0}
-            m={0}
-            border={0}
-            color={'gray.400'}
-            fontSize={'sm'}
-          >
-            {memo
-              ? memo
-              : '이력서에 대한 간단한 메모를 남겨보세요. ex. 12월 25일 제출 전까지 피드백 받기'}
-          </Text>
-        </Flex>
-      </Box>
+      <MemoBox
+        onOpen={onOpen}
+        memo={memo}
+      />
       <MemoModal />
     </>
   );

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -5,7 +5,8 @@ type ResumeListItem = {
   id: number;
   title: string;
   modifiedAt: string;
-  memo?: string;
+  position: string;
+  memo: string;
 };
 
 type MyResume = ResumeListItem & {


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<img width="630" alt="스크린샷 2023-11-28 오후 1 51 24" src="https://github.com/resumeme/Frontend/assets/91667853/c2a788ef-fa70-446d-91ba-b50bfc33c84c">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 선택 모달에서 각 이력서에 대한 희망 직무 데이터와 메모를 렌더링합니다.
  - 메모 박스에 대한 컴포넌트를 재사용하기 위해 분리했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
