### PR TITLE
Gmmq 737 fix: Modal 컴포넌트 CloseButton에 zIndex 추가

### DIFF
--- a/src/components/molecules/Modal/Modal.tsx
+++ b/src/components/molecules/Modal/Modal.tsx
@@ -41,7 +41,12 @@ const Modal = ({
         {...modalContentProps}
       >
         {title && <ModalHeader paddingTop={0}>{title}</ModalHeader>}
-        {hasCloseButton && <ModalCloseButton p={'1.5rem'} />}
+        {hasCloseButton && (
+          <ModalCloseButton
+            p={'1.5rem'}
+            zIndex={'docked'}
+          />
+        )}
         <ModalBody p={0}>{children}</ModalBody>
       </ModalContent>
     </ChakraModal>


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 모달 공통 변경사항
- `hasCloseButton` 프로퍼티로 취소 버튼이 생길 때, 버튼과 다른 요소가 겹쳐 클릭이 안되는 경우가 있었습니다.
- CloseButton에 zIndex를 `docked`로 넣어주어서 공통적으로 해결했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
