### PR TITLE
Gmmq 752 fix: 이벤트 상태 상수 수정, 준비 중일 때만 수정 가능

### DIFF
--- a/src/components/organisms/EventDetail/EventDetail.tsx
+++ b/src/components/organisms/EventDetail/EventDetail.tsx
@@ -9,13 +9,13 @@ import { ReadEvent } from '~/types/event/event';
 import { ReadMentor } from '~/types/mentor';
 
 type EventDetailProps = {
-  isAuthorizedMentor: boolean;
+  isEditable: boolean;
   mentor: ReadMentor;
   event: ReadEvent;
 };
 
 const EventDetail = ({
-  isAuthorizedMentor,
+  isEditable,
   mentor,
   event: {
     id,
@@ -34,7 +34,7 @@ const EventDetail = ({
       >
         <EventTitle
           id={id}
-          isAuthorizedMentor={isAuthorizedMentor}
+          isEditable={isEditable}
           eventStatus={status}
           title={title}
         />

--- a/src/components/organisms/EventDetail/EventTitle.tsx
+++ b/src/components/organisms/EventDetail/EventTitle.tsx
@@ -9,12 +9,12 @@ import { EventStatus } from '~/types/eventStatus';
 
 type EventTitle = {
   id: number;
-  isAuthorizedMentor: boolean;
+  isEditable: boolean;
   title: string;
   eventStatus: EventStatus;
 };
 
-const EventTitle = ({ id, isAuthorizedMentor, title, eventStatus }: EventTitle) => {
+const EventTitle = ({ id, isEditable, title, eventStatus }: EventTitle) => {
   const isActive = eventStatus === 'OPEN' || eventStatus === 'REOPEN';
   const navigate = useNavigate();
 
@@ -45,7 +45,7 @@ const EventTitle = ({ id, isAuthorizedMentor, title, eventStatus }: EventTitle) 
         {CONSTANTS.EVENT_STATUS[eventStatus]}
       </Label>
       <Spacer />
-      {isAuthorizedMentor && <OptionsButton options={options} />}
+      {isEditable && <OptionsButton options={options} />}
     </Flex>
   );
 };

--- a/src/constants/eventStatus.ts
+++ b/src/constants/eventStatus.ts
@@ -1,6 +1,6 @@
 export const EVENT_STATUS = {
-  READY: '모집 준비 중',
-  REOPEN: '재모집 중',
+  READY: '준비 중',
+  REOPEN: '재모집',
   CLOSE: '모집 마감',
   OPEN: '모집 중',
   FINISH: '종료',

--- a/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
@@ -45,7 +45,7 @@ const EventDetailPage = () => {
           }}
         />
         <EventDetail
-          isAuthorizedMentor={user?.id === event.mentorId}
+          isEditable={user?.id === event.mentorId && event.status === 'READY'}
           mentor={mentor}
           event={event}
         />


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/8976ac81-0563-41b9-94be-342d50e9542b)



## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
이벤트 상태 상수를  수정했습니다.
이벤트가 준비 중일 때만 수정 버튼이 나타나도록 했습니다.
props를 isEditable로 변경했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
