### PR TITLE
Gmmq 758 fix: 이력서 기술스택 빈 문자열 검사

### DIFF
--- a/src/components/organisms/ResumeBasicInput/BasicInfoView.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoView.tsx
@@ -36,7 +36,8 @@ const BasicInfoView = ({ position, skills, introduce, onEditClick }: BasicInfoVi
   };
 
   const renderSkills = () => {
-    if (skills.length > 0) {
+    const hasNoEmptyString = skills.every((skill) => skill !== '');
+    if (skills.length > 0 && hasNoEmptyString) {
       const skillLabels = skills.map((skill: string, index: number) => {
         return (
           <Badge

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -89,26 +89,28 @@ const CareerDetails = ({
             pl={1}
             gap={2}
           >
-            <Flex
-              pt={2}
-              gap={2}
-              flexWrap={'wrap'}
-            >
-              {skills?.map((skill, i) => (
-                <Label
-                  key={i}
-                  width={'fit-content'}
-                  bg={'gray.500'}
-                  fontSize={'xs'}
-                  py={0}
-                  color={'gray.100'}
-                  fontWeight={'medium'}
-                >
-                  {skill}
-                </Label>
-              ))}
-            </Flex>
-            <Text mt={5}>{careerContent}</Text>
+            {skills?.every((skill) => skill !== '') && (
+              <Flex
+                pt={2}
+                gap={2}
+                flexWrap={'wrap'}
+              >
+                {skills?.map((skill, i) => (
+                  <Label
+                    key={i}
+                    width={'fit-content'}
+                    bg={'gray.500'}
+                    fontSize={'xs'}
+                    py={0}
+                    color={'gray.100'}
+                    fontWeight={'medium'}
+                  >
+                    {skill}
+                  </Label>
+                ))}
+              </Flex>
+            )}
+            {careerContent && <Text mt={5}>{careerContent}</Text>}
           </Flex>
         </Flex>
         {duties?.map((duty) => (

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -89,7 +89,7 @@ const ProjectDetails = ({
               {teamMembers}
             </Text>
           )}
-          {skills && (
+          {skills?.every((skill) => skill !== '') && (
             <Flex
               pt={2}
               gap={2}

--- a/src/hooks/useStringToArray.tsx
+++ b/src/hooks/useStringToArray.tsx
@@ -7,8 +7,8 @@ export const useStringToArray = (
   (event: React.KeyboardEvent<HTMLInputElement>) => void,
   (targetIndex: number) => void,
 ] => {
-  const isEmptyString = (currentString: string) => currentString === '';
-  const [array, setSkills] = useState(defaultArray.every(isEmptyString) ? [] : defaultArray);
+  const hasNoEmptyString = defaultArray.every((currentString: string) => currentString !== '');
+  const [array, setSkills] = useState(hasNoEmptyString ? defaultArray : []);
 
   const handleArrayChange = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const { value: skill } = event.currentTarget;

--- a/src/hooks/useStringToArray.tsx
+++ b/src/hooks/useStringToArray.tsx
@@ -7,7 +7,8 @@ export const useStringToArray = (
   (event: React.KeyboardEvent<HTMLInputElement>) => void,
   (targetIndex: number) => void,
 ] => {
-  const [array, setSkills] = useState(defaultArray);
+  const isEmptyString = (currentString: string) => currentString === '';
+  const [array, setSkills] = useState(defaultArray.every(isEmptyString) ? [] : defaultArray);
 
   const handleArrayChange = (event: React.KeyboardEvent<HTMLInputElement>) => {
     const { value: skill } = event.currentTarget;


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="440" alt="스크린샷 2023-11-29 오후 12 25 11" src="https://github.com/resumeme/Frontend/assets/91667853/ece89c70-ede6-464e-bd62-0c6684e48135">
<img width="527" alt="스크린샷 2023-11-29 오후 12 27 27" src="https://github.com/resumeme/Frontend/assets/91667853/e5ec4a09-7bbd-4031-af58-059da9130cf9">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 기술스택을 저장하지 않으면 api에서 빈 문자열을 배열에 담아 반환하고 있습니다.
- 이로 인해 기술스택 length가 0보다 커서 요소가 있는 것으로 판단해 프론트에서 빈 값을 위 스크린샷처럼 렌더링하는 문제가 있었습니다.
- 배열에 빈 문자열만 들어있지 않은지 체크하는 방어코드를 추가했습니다.
  - 이제 빈 문자열만 들어있는 경우 빈 배열로 판단하여 기술스택을 렌더링하지 않습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
