### PR TITLE
Gmmq 756 fix: 업무경험 저장 후 폼 초기화

### DIFF
--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -42,12 +42,14 @@ const BasicInfoForm = ({
         onSuccess: () => {
           queryClient.refetchQueries({ queryKey: categoryKeys.basic(resumeId) });
           onSaveClick();
+          initializeSkills();
         },
       },
     );
   };
 
-  const [skills, handleSkillsetChange, handleItemDelete] = useStringToArray(defaultSkills);
+  const [skills, handleSkillsetChange, handleItemDelete, initializeSkills] =
+    useStringToArray(defaultSkills);
   const introduceValue = useWatch({ name: 'introduce', control });
   const introduceValueLength = introduceValue ? introduceValue.length : 0;
 

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -66,7 +66,11 @@ const CareerForm = ({
     onMutateSuccess: quitEdit,
   });
 
-  const { fields, append, remove } = useFieldArray({
+  const {
+    fields,
+    append,
+    remove: removeDuties,
+  } = useFieldArray({
     control,
     name: 'duties',
   });
@@ -81,18 +85,22 @@ const CareerForm = ({
     }
     body.skills = skills;
     body.duties = body.duties || [];
+    const initializeForm = () => {
+      initializeSkills();
+      removeDuties();
+    };
     if (!isEdit) {
       postCareerMutate(
         { resumeId, body },
         {
-          onSuccess: initializeSkills,
+          onSuccess: initializeForm,
         },
       );
     } else if (isEdit && blockId) {
       patchCareerMutate(
         { resumeId, blockId, body },
         {
-          onSuccess: initializeSkills,
+          onSuccess: initializeForm,
         },
       );
     }
@@ -212,7 +220,7 @@ const CareerForm = ({
                   index={index}
                   register={register}
                   errors={errors}
-                  remove={remove}
+                  remove={removeDuties}
                   control={control}
                 />
               ))}

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -71,7 +71,9 @@ const CareerForm = ({
     name: 'duties',
   });
 
-  const [skills, handleArrayChange, handleItemDelete] = useStringToArray(defaultValues?.skills);
+  const [skills, handleArrayChange, handleItemDelete, initializeSkills] = useStringToArray(
+    defaultValues?.skills,
+  );
 
   const onSubmit = handleSubmit((body) => {
     if (!resumeId) {
@@ -80,9 +82,19 @@ const CareerForm = ({
     body.skills = skills;
     body.duties = body.duties || [];
     if (!isEdit) {
-      postCareerMutate({ resumeId, body });
+      postCareerMutate(
+        { resumeId, body },
+        {
+          onSuccess: initializeSkills,
+        },
+      );
     } else if (isEdit && blockId) {
-      patchCareerMutate({ resumeId, blockId, body });
+      patchCareerMutate(
+        { resumeId, blockId, body },
+        {
+          onSuccess: initializeSkills,
+        },
+      );
     }
   });
 
@@ -104,9 +116,6 @@ const CareerForm = ({
     }
   }, [isEdit, setShowForm]);
 
-  // if (defaultValues?.skills && defaultValues?.skills?.length > 0) {
-  //   setValue('skills', ['']);
-  // }
   return (
     <Flex
       direction={'column'}

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -54,7 +54,9 @@ const ProjectForm = ({
     onMutateSuccess: quitEdit,
   });
 
-  const [skills, handleSkills, handleDeleteSkills] = useStringToArray(defaultValues?.skills);
+  const [skills, handleSkills, handleDeleteSkills, initializeSkills] = useStringToArray(
+    defaultValues?.skills,
+  );
 
   const onSubmit: SubmitHandler<Project> = (body) => {
     if (!resumeId) {
@@ -63,9 +65,19 @@ const ProjectForm = ({
     body.skills = skills;
     body.team = Boolean(body.team);
     if (!isEdit) {
-      postProjectMutate({ resumeId, body });
+      postProjectMutate(
+        { resumeId, body },
+        {
+          onSuccess: initializeSkills,
+        },
+      );
     } else if (isEdit && blockId) {
-      patchResumeProjectMutate({ resumeId, blockId, body });
+      patchResumeProjectMutate(
+        { resumeId, blockId, body },
+        {
+          onSuccess: initializeSkills,
+        },
+      );
     }
   };
 

--- a/src/hooks/useStringToArray.tsx
+++ b/src/hooks/useStringToArray.tsx
@@ -6,6 +6,7 @@ export const useStringToArray = (
   string[],
   (event: React.KeyboardEvent<HTMLInputElement>) => void,
   (targetIndex: number) => void,
+  () => void,
 ] => {
   const [array, setSkills] = useState(defaultArray);
 
@@ -35,5 +36,9 @@ export const useStringToArray = (
     setSkills(newArray);
   };
 
-  return [array, handleArrayChange, handleItemDelete];
+  const initialize = () => {
+    setSkills([]);
+  };
+
+  return [array, handleArrayChange, handleItemDelete, initialize];
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서의 업무 경험 작성할 때 기존에 저장했던 기술스택, 주요업무가 초기화되지 않고 새로 추가한 아이템에도 나타나는 문제가 있었습니다.
- 각각 skills와 duties 를 초기화하도록 수정했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
