### PR TITLE
fix: 이벤트 상세 페이지 비회원일 때 팔로우, 신청 이력 관련 api 호출 막음

### DIFF
--- a/src/components/molecules/MentorProfile/MentorProfile.tsx
+++ b/src/components/molecules/MentorProfile/MentorProfile.tsx
@@ -31,7 +31,7 @@ const MentorProfile = ({
 
   const { nickname, introduce, imageUrl, careerYear, experiencedPositions } = mentor;
 
-  const { data: isApplied } = useGetIsAppliedEvent({ eventId: id.toString() });
+  const { data: isApplied } = useGetIsAppliedEvent({ eventId: id.toString(), role: user?.role });
 
   const getApplyButtonText = (status: EventStatus) => {
     if (status === 'OPEN' || status === 'REOPEN') {
@@ -42,9 +42,7 @@ const MentorProfile = ({
     }
     return CONSTANTS.EVENT_STATUS[status];
   };
-  const {
-    data: { id: followId },
-  } = useGetMentorFollow({ mentorId });
+  const { data: followData } = useGetMentorFollow({ mentorId, role: user?.role });
   const { mutate: deleteMentorFollow } = useDeleteMentorFollow();
   const { mutate: mentorFollow } = usePostMentorFollow();
 
@@ -75,10 +73,10 @@ const MentorProfile = ({
           w={'fit-content'}
           h={'fit-content'}
           bg={'inherit'}
-          icon={followId ? <FaBell size="1.2rem" /> : <FaRegBell size="1.2rem" />}
+          icon={followData?.id ? <FaBell size="1.2rem" /> : <FaRegBell size="1.2rem" />}
           onClick={
-            followId
-              ? () => deleteMentorFollow({ followId: Number(followId) })
+            followData?.id
+              ? () => deleteMentorFollow({ followId: Number(followData?.id) })
               : () => mentorFollow({ mentorId })
           }
           aria-label="follow"

--- a/src/queries/follow/details/useGetMentorFollow.ts
+++ b/src/queries/follow/details/useGetMentorFollow.ts
@@ -1,10 +1,12 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { followKeys } from '../followKeys.const';
 import { getMentorFollow } from '~/api/follow/details/getMentorFollow';
+import { UserRole } from '~/types/user';
 
-export const useGetMentorFollow = ({ mentorId }: { mentorId: number }) => {
-  return useSuspenseQuery({
+export const useGetMentorFollow = ({ mentorId, role }: { mentorId: number; role?: UserRole }) => {
+  return useQuery({
     queryKey: followKeys.all,
     queryFn: () => getMentorFollow({ mentorId }),
+    enabled: !!(role === 'mentee'),
   });
 };

--- a/src/queries/user/useGetIsAppliedEvent.ts
+++ b/src/queries/user/useGetIsAppliedEvent.ts
@@ -1,10 +1,15 @@
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { userKeys } from './userKeys';
 import { GetIsAppliedEvent, getIsAppliedEvent } from '~/api/user/getIsAppliedEvent';
+import { UserRole } from '~/types/user';
 
-export const useGetIsAppliedEvent = ({ eventId }: GetIsAppliedEvent) => {
-  return useSuspenseQuery({
+export const useGetIsAppliedEvent = ({
+  eventId,
+  role,
+}: GetIsAppliedEvent & { role?: UserRole }) => {
+  return useQuery({
     queryKey: userKeys.isAppliedEvent(eventId),
     queryFn: () => getIsAppliedEvent({ eventId }),
+    enabled: !!(role === 'mentee'),
   });
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 현재 멘티가 이벤트 상세 페이지에 접근할 때 `멘토 팔로우 여부`, `이벤트 신청 여부`를 알기 위해 api를 호출하고 있습니다.
- 멘티가 아닌 회원이거나 회원이 아닌 경우에는 이 api 호출을 막도록 수정했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
