### PR TITLE
Gmmq 638 fix: 카테고리 블럭 낙관적 삭제 로직 수정

### DIFF
--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -16,7 +16,7 @@ const ActivityDetails = ({
 }: DetailsComponentProps<ReadActivity>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Activity>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Activity, ReadActivity>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.activity(resumeId),
   });

--- a/src/components/organisms/ResumeDetails/AwardDetails.tsx
+++ b/src/components/organisms/ResumeDetails/AwardDetails.tsx
@@ -16,7 +16,7 @@ const AwardDetails = ({
 }: DetailsComponentProps<ReadAward>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteAward } = useOptimisticDeleteCategory<Award>({
+  const { mutate: deleteAward } = useOptimisticDeleteCategory<Award, ReadAward>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.award(resumeId),
   });

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -26,7 +26,7 @@ const CareerDetails = ({
 }: DetailsComponentProps<ReadCareer>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Career>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Career, ReadCareer>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.career(resumeId),
   });

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -15,7 +15,7 @@ const LanguageDetails = ({
 }: DetailsComponentProps<ReadLanguage>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Language>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Language, ReadLanguage>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.language(resumeId),
   });

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -25,7 +25,7 @@ const ProjectDetails = ({
 }: DetailsComponentProps<ReadProject>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Project>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Project, ReadProject>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.project(resumeId),
   });

--- a/src/components/organisms/ResumeDetails/TrainingDetails.tsx
+++ b/src/components/organisms/ResumeDetails/TrainingDetails.tsx
@@ -25,7 +25,7 @@ const TraningDetails = ({
 }: DetailsComponentProps<ReadTraining>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Training>({
+  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Training, ReadTraining>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.training(resumeId),
   });

--- a/src/queries/resume/useOptimisticDeleteCategory.ts
+++ b/src/queries/resume/useOptimisticDeleteCategory.ts
@@ -1,14 +1,14 @@
 import { useToast } from '@chakra-ui/react';
 import { QueryKey, useMutation, useQueryClient } from '@tanstack/react-query';
 import { DeleteResumeCategory } from '~/types/api/deleteResumeCategory';
-import { Categories } from '~/types/resume/categories';
+import { Categories, ReadCategories } from '~/types/resume/categories';
 
 type UseOptimisticDelete<T extends Categories> = {
   mutationFn: DeleteResumeCategory<T>;
   TARGET_QUERY_KEY: QueryKey;
   onMutateSuccess?: () => void;
 };
-export const useOptimisticDeleteCategory = <T extends Categories>({
+export const useOptimisticDeleteCategory = <T extends Categories, U extends ReadCategories>({
   mutationFn,
   TARGET_QUERY_KEY,
   onMutateSuccess,
@@ -18,11 +18,11 @@ export const useOptimisticDeleteCategory = <T extends Categories>({
 
   return useMutation({
     mutationFn,
-    onMutate: async (newCategoryBlock) => {
+    onMutate: async ({ blockId: targetBlockId }) => {
       await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
       const previousCategoryData = queryClient.getQueryData(TARGET_QUERY_KEY);
-      queryClient.setQueryData(TARGET_QUERY_KEY, (old: T[]) => {
-        return [...old, newCategoryBlock];
+      queryClient.setQueryData(TARGET_QUERY_KEY, (old: U[]) => {
+        return old.filter((blockData: U) => blockData.componentId !== targetBlockId);
       });
       return { previousCategoryData };
     },


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
### 수정 전
삭제 후 빈 블럭이 추가됐다가 사라지는 문제
![ezgif com-gif-maker](https://github.com/resumeme/Frontend/assets/91667853/9a405193-1f7a-450d-8702-15337105d5eb)
### 수정 후
삭제 후 바로 사라짐
![ezgif com-gif-maker (1)](https://github.com/resumeme/Frontend/assets/91667853/84cfd892-8198-4dff-9865-11be99ee58c9)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 블럭 삭제에 대한 낙관적 업데이트 로직을 수정했습니다.
- 삭제 타겟 아이디와 일치하는 아이디의 블럭을 필터링해서 제거해줍니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
