### PR TITLE
Gmmq 646 style: 마이페이지 (이력서 관리, 첨삭 관리) UI 리터치

### DIFF
--- a/src/components/molecules/MemoBox/MemoBox.tsx
+++ b/src/components/molecules/MemoBox/MemoBox.tsx
@@ -33,7 +33,7 @@ const MemoBox = ({ onOpen, memo }: MemoBoxProps) => {
           p={0}
           m={0}
           border={0}
-          color={'gray.400'}
+          color={'gray.500'}
           fontSize={'sm'}
         >
           {memo

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, Icon, Link, Spacer, Text, Tooltip, useToast } from '@chakra-ui/react';
+import { Box, Flex, Icon, Link, Spacer, Text, Tooltip, useToast } from '@chakra-ui/react';
 import { FiFileText } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 import { Link as ReactRouterLink } from 'react-router-dom';
@@ -11,6 +11,16 @@ import { FeedbackResume } from '~/types/resume/resumeListItem';
 
 type FeedbackManagementItemProps = {
   resume: FeedbackResume;
+};
+
+const STATUS_SCHEME = {
+  APPLY: { color: 'teal.600', text: '멘토의 피드백을 기다리는 중이에요. (1/3)' },
+  FEEDBACK_COMPLETE: {
+    color: 'primary.900',
+    text: '멘토의 피드백이 완료되었어요. 확인 후 수정해보세요. (2/3)',
+  },
+  COMPLETE: { color: 'gray.500', text: '수정 사항이 반영되고 이벤트가 종료되었어요. (3/3)' },
+  REJECT: { color: 'red.600', text: '신청이 반려되었어요. 반려 사유를 확인하세요.' },
 };
 
 const FeedbackManagementItem = ({
@@ -34,20 +44,6 @@ const FeedbackManagementItem = ({
     }
   };
 
-  const StatusStepper = () => {
-    return (
-      <Label
-        fontSize={'0.75rem'}
-        h={'max-content'}
-        p={'0.2rem 0.37rem'}
-        borderRadius={'0.3125rem'}
-        bg={'gray.500'}
-      >
-        {CONSTANTS.RESUME_STATUS[status]}
-      </Label>
-    );
-  };
-
   return (
     <>
       <Flex
@@ -60,12 +56,28 @@ const FeedbackManagementItem = ({
           align={'center'}
           gap={2}
         >
-          <Flex
-            direction={'column'}
-            justify={'space-between'}
+          <Tooltip
+            label={STATUS_SCHEME[status].text}
+            fontSize={'sm'}
+            color={'gray.700'}
+            bg={'white'}
+            openDelay={500}
+            placement="auto"
+            hasArrow
           >
-            <StatusStepper />
-          </Flex>
+            <Box>
+              <Label
+                fontSize={'0.75rem'}
+                p={'0.2rem 0.37rem'}
+                borderRadius={'0.3125rem'}
+                textAlign={'center'}
+                cursor={'pointer'}
+                bg={STATUS_SCHEME[status].color}
+              >
+                {CONSTANTS.RESUME_STATUS[status]}
+              </Label>
+            </Box>
+          </Tooltip>
 
           <Tooltip
             openDelay={500}
@@ -78,8 +90,8 @@ const FeedbackManagementItem = ({
               type="button"
               w={'fit-content'}
               noOfLines={1}
-              fontSize={'1.35rem'}
-              fontWeight={600}
+              fontSize={'1.25rem'}
+              fontWeight={700}
               color={'gray.800'}
               as={ReactRouterLink}
               to={appPaths.eventDetail(eventId)}
@@ -88,40 +100,38 @@ const FeedbackManagementItem = ({
             </Link>
           </Tooltip>
         </Flex>
-        <Flex>
-          <Flex
-            direction={'column'}
-            justify={'center'}
+        <Flex
+          direction={'column'}
+          align={'space-between'}
+        >
+          <Text
+            flexShrink={0}
+            as={'span'}
+            fontSize={'0.875rem'}
+            color={'gray.500'}
           >
+            {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
+              endDate,
+            ).toLocaleDateString()}`}
+          </Text>
+          <Flex
+            flexShrink={0}
+            align={'center'}
+            justify={'flex-end'}
+            gap={'0.5rem'}
+          >
+            <Badge
+              type="mentee"
+              py={0}
+            >
+              멘토
+            </Badge>
             <Text
-              flexShrink={0}
-              as={'span'}
               fontSize={'0.875rem'}
-              color={'gray.500'}
+              fontWeight={600}
             >
-              {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
-                endDate,
-              ).toLocaleDateString()}`}
+              {mentorName}
             </Text>
-            <Flex
-              flexShrink={0}
-              align={'center'}
-              justify={'flex-end'}
-              gap={'0.5rem'}
-            >
-              <Badge
-                type="mentee"
-                py={0}
-              >
-                멘토
-              </Badge>
-              <Text
-                fontSize={'0.875rem'}
-                fontWeight={600}
-              >
-                {mentorName}
-              </Text>
-            </Flex>
           </Flex>
         </Flex>
       </Flex>
@@ -140,7 +150,6 @@ const FeedbackManagementItem = ({
           color={'gray.600'}
           boxSize={'1rem'}
         />
-        {/*TODO 주석해제 {resumeTitle && <Text>{resumeTitle}</Text>} */}
         <Tooltip
           maxW={'xl'}
           noOfLines={2}
@@ -161,7 +170,7 @@ const FeedbackManagementItem = ({
           </Text>
         </Tooltip>
         <Spacer />
-        {status && (
+        {status !== 'REJECT' && status !== 'APPLY' && (
           <Button
             bg={status === 'COMPLETE' ? 'gray.600' : 'primary.800'}
             borderRadius={'0.3125rem'}
@@ -174,7 +183,7 @@ const FeedbackManagementItem = ({
               opacity: '0.65',
             }}
           >
-            {status === 'COMPLETE' ? '확인' : '피드백 반영하기'}
+            {status === 'COMPLETE' ? '피드백 내역 확인' : '피드백 반영하기'}
           </Button>
         )}
       </Flex>

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -59,10 +59,10 @@ const FeedbackManagementItem = ({
           <Tooltip
             label={STATUS_SCHEME[status].text}
             fontSize={'sm'}
-            color={'gray.700'}
-            bg={'white'}
+            color="white"
+            bg={STATUS_SCHEME[status].color}
             openDelay={500}
-            placement="auto"
+            placement="top-start"
             hasArrow
           >
             <Box>
@@ -83,6 +83,7 @@ const FeedbackManagementItem = ({
             openDelay={500}
             label={title}
             fontSize={'sm'}
+            placement="top-start"
             color={'gray.700'}
             bg={'white'}
           >
@@ -90,8 +91,8 @@ const FeedbackManagementItem = ({
               type="button"
               w={'fit-content'}
               noOfLines={1}
-              fontSize={'1.25rem'}
-              fontWeight={700}
+              fontSize={'1.3rem'}
+              fontWeight={600}
               color={'gray.800'}
               as={ReactRouterLink}
               to={appPaths.eventDetail(eventId)}
@@ -104,16 +105,6 @@ const FeedbackManagementItem = ({
           direction={'column'}
           align={'space-between'}
         >
-          <Text
-            flexShrink={0}
-            as={'span'}
-            fontSize={'0.875rem'}
-            color={'gray.500'}
-          >
-            {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
-              endDate,
-            ).toLocaleDateString()}`}
-          </Text>
           <Flex
             flexShrink={0}
             align={'center'}
@@ -133,6 +124,16 @@ const FeedbackManagementItem = ({
               {mentorName}
             </Text>
           </Flex>
+          <Text
+            flexShrink={0}
+            as={'span'}
+            fontSize={'0.875rem'}
+            color={'gray.500'}
+          >
+            {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
+              endDate,
+            ).toLocaleDateString()}`}
+          </Text>
         </Flex>
       </Flex>
 

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -1,8 +1,8 @@
 import { Flex, Icon, Link, Spacer, Text, Tooltip, useToast } from '@chakra-ui/react';
-import { BiCommentError } from 'react-icons/bi';
-import { MdOutlineArticle } from 'react-icons/md';
+import { FiFileText } from 'react-icons/fi';
 import { useNavigate } from 'react-router-dom';
 import { Link as ReactRouterLink } from 'react-router-dom';
+import { Badge } from '~/components/atoms/Badge';
 import { Button } from '~/components/atoms/Button';
 import { Label } from '~/components/atoms/Label';
 import { appPaths } from '~/config/paths';
@@ -19,8 +19,8 @@ const FeedbackManagementItem = ({
   const navigate = useNavigate();
 
   const toast = useToast();
-  // TODO api 상태 정해지면 label 컬러 추가
 
+  // TODO api 상태 정해지면 label 컬러 추가
   const handleClick = () => {
     if (status === 'COMPLETE') {
       navigate(appPaths.feedbackComplete(resumeId, eventId));
@@ -34,74 +34,111 @@ const FeedbackManagementItem = ({
     }
   };
 
+  const StatusStepper = () => {
+    return (
+      <Label
+        fontSize={'0.75rem'}
+        h={'max-content'}
+        p={'0.2rem 0.37rem'}
+        borderRadius={'0.3125rem'}
+        bg={'gray.500'}
+      >
+        {CONSTANTS.RESUME_STATUS[status]}
+      </Label>
+    );
+  };
+
   return (
     <>
       <Flex
-        align={'center'}
-        gap={'1rem'}
+        gap={'0.5rem'}
+        justify={'center'}
         w={'full'}
       >
-        <Link
-          type="button"
-          w={'fit-content'}
-          noOfLines={1}
-          fontSize={'1.5rem'}
-          fontWeight={600}
-          color={'gray.800'}
-          as={ReactRouterLink}
-          to={appPaths.eventDetail(eventId)}
-        >
-          {title}
-        </Link>
-        <Label
-          fontSize={'0.75rem'}
-          p={'0.25rem 0.37rem'}
-          borderRadius={'0.3125rem'}
-        >
-          {CONSTANTS.RESUME_STATUS[status]}
-        </Label>
-        <Spacer />
-        <Text
-          flexShrink={0}
-          as={'span'}
-          fontSize={'0.875rem'}
-          color={'gray.500'}
-        >
-          {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
-            endDate,
-          ).toLocaleDateString()}`}
-        </Text>
         <Flex
-          flexShrink={0}
+          w={'70%'}
           align={'center'}
-          gap={'0.5rem'}
+          gap={2}
         >
-          <Icon
-            color={'highlight.900'}
-            as={BiCommentError}
-            w={'1.25rem'}
-          />
-          <Text
-            fontSize={'0.875rem'}
-            fontWeight={600}
+          <Flex
+            direction={'column'}
+            justify={'space-between'}
           >
-            {mentorName}
-          </Text>
+            <StatusStepper />
+          </Flex>
+
+          <Tooltip
+            openDelay={500}
+            label={title}
+            fontSize={'sm'}
+            color={'gray.700'}
+            bg={'white'}
+          >
+            <Link
+              type="button"
+              w={'fit-content'}
+              noOfLines={1}
+              fontSize={'1.35rem'}
+              fontWeight={600}
+              color={'gray.800'}
+              as={ReactRouterLink}
+              to={appPaths.eventDetail(eventId)}
+            >
+              {title}
+            </Link>
+          </Tooltip>
+        </Flex>
+        <Flex>
+          <Flex
+            direction={'column'}
+            justify={'center'}
+          >
+            <Text
+              flexShrink={0}
+              as={'span'}
+              fontSize={'0.875rem'}
+              color={'gray.500'}
+            >
+              {`${new Date(startDate).toLocaleDateString()} ~ ${new Date(
+                endDate,
+              ).toLocaleDateString()}`}
+            </Text>
+            <Flex
+              flexShrink={0}
+              align={'center'}
+              justify={'flex-end'}
+              gap={'0.5rem'}
+            >
+              <Badge
+                type="mentee"
+                py={0}
+              >
+                멘토
+              </Badge>
+              <Text
+                fontSize={'0.875rem'}
+                fontWeight={600}
+              >
+                {mentorName}
+              </Text>
+            </Flex>
+          </Flex>
         </Flex>
       </Flex>
+
       <Flex
-        mt={'1.75rem'}
+        mt={'1rem'}
         borderRadius={'0.3125rem'}
-        p={'0.75rem 1rem'}
+        p={'0.5rem 0.75rem'}
         bg={'gray.200'}
         alignItems={'center'}
         w={'full'}
         gap={'0.69rem'}
       >
         <Icon
-          as={MdOutlineArticle}
-          color={'gray.500'}
-          w={'1.25rem'}
+          as={FiFileText}
+          color={'gray.600'}
+          boxSize={'1rem'}
         />
         {/*TODO 주석해제 {resumeTitle && <Text>{resumeTitle}</Text>} */}
         <Tooltip
@@ -126,15 +163,18 @@ const FeedbackManagementItem = ({
         <Spacer />
         {status && (
           <Button
-            bg={'gray.500'}
+            bg={status === 'COMPLETE' ? 'gray.600' : 'primary.800'}
             borderRadius={'0.3125rem'}
             fontSize={'0.75rem'}
-            p={'0.25rem 1.25rem'}
+            p={'0.25rem 0.5rem'}
             h={'fit-content'}
             w={'fit-content'}
             onClick={handleClick}
+            _hover={{
+              opacity: '0.65',
+            }}
           >
-            {status === 'COMPLETE' ? '첨삭 내역 확인' : '수정하기'}
+            {status === 'COMPLETE' ? '확인' : '피드백 반영하기'}
           </Button>
         )}
       </Flex>

--- a/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
+++ b/src/components/organisms/ResumeManagementItem/ResumeItem.tsx
@@ -1,4 +1,4 @@
-import { Flex, FormErrorMessage, Spacer, Text, useDisclosure } from '@chakra-ui/react';
+import { Flex, FormErrorMessage, Spacer, Text, Tooltip, useDisclosure } from '@chakra-ui/react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
@@ -121,15 +121,28 @@ const ResumeItem = ({ resume: { id, modifiedAt, title, memo } }: ResumeItemProps
         />
       </Flex>
       <Link to={appPaths.resumeDetail(id)}>
-        <Text
-          noOfLines={1}
-          mt={'1.5rem'}
-          fontSize={'1.5rem'}
-          fontWeight={600}
-          color={'gray.800'}
+        <Tooltip
+          openDelay={500}
+          label={title}
+          placement="top-start"
+          bg={'white'}
+          color={'gray.600'}
+          fontSize={'xs'}
         >
-          {title}
-        </Text>
+          <Text
+            noOfLines={1}
+            mt={'0.8rem'}
+            fontSize={'1.5rem'}
+            fontWeight={600}
+            color={'gray.800'}
+            _hover={{
+              textDecoration: 'underline',
+              textUnderlineOffset: '0.2rem',
+            }}
+          >
+            {title}
+          </Text>
+        </Tooltip>
       </Link>
       <MemoBox
         onOpen={onOpen}

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,6 +1,6 @@
 const RESUME_STATUS = {
-  APPLY: '피드백 중',
-  FEEDBACK_COMPLETE: '피드백 완료',
+  APPLY: '대기중',
+  FEEDBACK_COMPLETE: '피드백',
   COMPLETE: '종료',
   REJECT: '반려',
 };

--- a/src/constants/status.ts
+++ b/src/constants/status.ts
@@ -1,8 +1,8 @@
 const RESUME_STATUS = {
-  APPLY: '신청 완료',
-  COMPLETE: '수정 완료',
-  FEEDBACK_COMPLETE: '첨삭 완료',
-  REJECT: '반려 됨',
+  APPLY: '피드백 중',
+  FEEDBACK_COMPLETE: '피드백 완료',
+  COMPLETE: '종료',
+  REJECT: '반려',
 };
 
 export { RESUME_STATUS };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/6def10c2-2cb7-4ffd-b135-2baa8ba1cbe1)

![image](https://github.com/resumeme/Frontend/assets/74141521/f7eb1d39-77ba-4c92-8cfd-4d582d43bb46)

![image](https://github.com/resumeme/Frontend/assets/74141521/e7db1706-3efb-4aad-bd21-ddea1dcbd619)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 첨삭 관리 탭
- 멘토 왼쪽의 아이콘을 빼고 `멘토` 뱃지를 넣어주었습니다.
- 이력서 관리 탭의 메모 아이콘과 헷갈리지 않도록 다른 아이콘을 넣어주었습니다.
- 레이아웃 수정 (Flex 구조 수정)
- 툴팁 추가 (상태에 따라 다르게 렌더링)
- REJECT와 APPLY일 때는 내 이력서 오른쪽의 버튼이 보이지 않게 했습니다.
  - COMPLETE일 때는 `피드백 내역 확인` 버튼이 렌더링
  - FEEDBACK_COMPLETE일 때는 `피드백 반영하기` 버튼이 렌더링
- 각 버튼의 배경 색이 상태에 따라 다르게 렌더링되게 했습니다.
- 버튼 hover시 opacity를 낮춰 버튼처럼 보이도록 리터치했습니다.

### 이력서 관리 탭
- hover시 이력서 제목에 underline 스타일 적용
- 툴팁 적용 (이력서 제목이 길 때 툴팁으로 확인할 수 있도록)
- 간격 수정 (이력서 제목과 수정 날짜 사이 간격을 줄였습니다)

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
