### PR TITLE
Gmmq 770 fix: 기술스택 태그 위치 조정

### DIFF
--- a/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/BasicInfoForm.tsx
@@ -116,16 +116,16 @@ const BasicInfoForm = ({
                   error={errors.skills}
                   defaultValue={''}
                 />
-                {skills.length > 0 && (
-                  <DynamicTags
-                    tagsArray={skills}
-                    handleItemDelete={handleItemDelete}
-                  />
-                )}
               </Flex>
             </FormControl>
           </Box>
         </Tooltip>
+        {skills.length > 0 && (
+          <DynamicTags
+            tagsArray={skills}
+            handleItemDelete={handleItemDelete}
+          />
+        )}
         <Box>
           <FormControl isInvalid={Boolean(errors.introduce)}>
             <FormTextarea

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -226,12 +226,14 @@ const ProjectForm = ({
                         register={{ ...register('skills') }}
                         onKeyDown={handleSkills}
                       />
-                      <DynamicTags
-                        handleItemDelete={handleDeleteSkills}
-                        tagsArray={skills}
-                      />
                     </Box>
                   </Tooltip>
+                  {skills.length > 0 && (
+                    <DynamicTags
+                      handleItemDelete={handleDeleteSkills}
+                      tagsArray={skills}
+                    />
+                  )}
                 </Flex>
               </FormControl>
               <FormControl>


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
전
<img width="602" alt="스크린샷 2023-11-30 오후 6 03 59" src="https://github.com/resumeme/Frontend/assets/91667853/a834452a-4e2c-432b-aef9-a0a6626bdf4e">
후
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="534" alt="스크린샷 2023-11-30 오후 6 03 47" src="https://github.com/resumeme/Frontend/assets/91667853/dbca131e-d9f0-4016-9d86-140572a4affd">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- ProjectForm의 기술스택 태그들이 input박스에 붙어서 나타나는 현상을 해결했습니다.
- 추가로 기술스택에 대한 툴팁이 input 옆에 뜨도록 고정되어있는 게 좋을 것 같아 BasicInfoForm을 위 스크린샷과 같이 수정했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
