### PR TITLE
feat: 피드백 관리 페이지 - 반려 상태와 반려메시지 렌더링 / 사소한 스타일 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,10 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0"
     />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="upgrade-insecure-requests"
+    />
     <title>이력, 써 resume.me</title>
   </head>
   <body>

--- a/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
+++ b/src/components/organisms/FeedbackManagementItem/FeedbackManagementItem.tsx
@@ -33,13 +33,13 @@ const FeedbackManagementItem = ({
     title: eventTitle,
     eventId,
     resumeTitle,
+    rejectMessage,
   },
 }: FeedbackManagementItemProps) => {
   const navigate = useNavigate();
 
   const toast = useToast();
 
-  // TODO api 상태 정해지면 label 컬러 추가
   const handleClick = () => {
     if (status === 'COMPLETE') {
       navigate(appPaths.feedbackComplete(resumeId, eventId));
@@ -52,6 +52,8 @@ const FeedbackManagementItem = ({
       });
     }
   };
+
+  const isReject = status === 'REJECT';
 
   return (
     <>
@@ -164,18 +166,18 @@ const FeedbackManagementItem = ({
           maxW={'xl'}
           noOfLines={2}
           placement="bottom-start"
-          label={resumeTitle}
+          label={!isReject ? resumeTitle : rejectMessage}
           aria-label="tooltip"
           borderRadius={'xl'}
           fontSize={'sm'}
-          bg={'gray.300'}
-          color={'gray.600'}
+          bg={'white'}
+          color={'gray.700'}
         >
           <Text
             as={'span'}
             noOfLines={1}
           >
-            {resumeTitle}
+            {!isReject ? resumeTitle : rejectMessage}
           </Text>
         </Tooltip>
         <Spacer />

--- a/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
+++ b/src/components/templates/EventGridTemplate/EventGridTemplate.tsx
@@ -1,7 +1,7 @@
-import { Flex, Heading, Text } from '@chakra-ui/react';
+import { Box, Flex, Heading, Text, Icon } from '@chakra-ui/react';
 import { useCallback, useEffect, useState } from 'react';
+import { HiPlusCircle } from 'react-icons/hi';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button } from '~/components/atoms/Button';
 import { Pagination } from '~/components/molecules/Pagination';
 import { EventGrid } from '~/components/organisms/EventGrid';
 import { appPaths } from '~/config/paths';
@@ -55,7 +55,41 @@ const EventGridTemplate = () => {
         </Heading>
         {user?.role === 'mentor' && (
           <Link to={appPaths.eventCreate()}>
-            <Button size={'md'}>이벤트 생성</Button>
+            <Box role="group">
+              <Flex
+                align={'center'}
+                gap={1}
+                _groupHover={{
+                  transform: 'translateY(-1px)',
+                  transition: 'all .25s linear',
+                }}
+              >
+                <Icon
+                  as={HiPlusCircle}
+                  color={'gray.400'}
+                  fontSize={'1.25rem'}
+                  verticalAlign={'center'}
+                  _groupHover={{
+                    color: 'primary.900',
+                    transition: 'all .6s linear',
+                    transform: 'rotateX(180deg)',
+                  }}
+                />
+                <Text
+                  fontSize={'md'}
+                  fontWeight={'semibold'}
+                  color={'gray.400'}
+                  textDecoration="underline 2px"
+                  textUnderlineOffset="0.25rem"
+                  _groupHover={{
+                    color: 'primary.900',
+                    transition: 'all .25s linear',
+                  }}
+                >
+                  이벤트 생성
+                </Text>
+              </Flex>
+            </Box>
           </Link>
         )}
       </Flex>

--- a/src/components/templates/SignInTemplate/SignInTemplate.tsx
+++ b/src/components/templates/SignInTemplate/SignInTemplate.tsx
@@ -1,10 +1,11 @@
 import { ChevronRightIcon } from '@chakra-ui/icons';
-import { Box, Divider, Flex, HStack, Heading, Icon, Text, VStack } from '@chakra-ui/react';
+import { Image, Divider, Flex, HStack, Heading, Icon, Text, VStack } from '@chakra-ui/react';
 import { Link } from '@chakra-ui/react';
 import { AiFillGithub } from 'react-icons/ai';
 import { RiNotionFill } from 'react-icons/ri';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { OAuthSignInButton } from '~/components/molecules/OAuthSignInButton';
+import { assets } from '~/config/assets';
 import CONSTANTS from '~/constants';
 
 const TEXT = {
@@ -64,12 +65,11 @@ const SignInTemplate = () => {
 const Logo = () => {
   return (
     <Flex align="center">
-      <Box
-        bg="gray.800"
-        w="24px"
-        h="24px"
-        borderRadius="md"
-        mr="12px"
+      <Image
+        h={'24px'}
+        minH={'24px'}
+        src={assets.logoSvg}
+        mr="0.7rem"
       />
       <Heading
         fontSize={'xl'}

--- a/src/types/resume/resumeListItem.ts
+++ b/src/types/resume/resumeListItem.ts
@@ -14,7 +14,6 @@ type MyResume = ResumeListItem & {
 };
 
 type FeedbackResume = {
-  //TODO - api 수정 후 변경 - ?제거, title-eventTItle로 변경
   resumeTitle?: string;
   eventId: number;
   resumeId: number;
@@ -23,6 +22,7 @@ type FeedbackResume = {
   mentorName: string;
   startDate: string;
   endDate: string;
+  rejectMessage?: string;
 };
 
 export type { MyResume, ResumeListItem, FeedbackResume };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
### 피드백 관리 페이지
- 멘티가 이벤트 신청 후, 반려되었을 때 피드백 관리 페이지에서 반려 상태와 반려 메시지를 렌더링
  - 서버 연동 이슈로 아직 테스트를 못해봤습니다. 킹론상 제대로 보일 것.

### 스타일 수정
- 이벤트 리스트 페이지에서 멘토에게 보이는 '이벤트 생성' 임시 버튼 제거하고 새 디자인으로 버튼 구현
- 가입 페이지의 헤더부분 임시 로고 제거하고 확정된 로고로 변경

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
