### PR TITLE
hotfix: 이력서 작성완료 버튼 추가

### DIFF
--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,6 +1,7 @@
-import { Flex } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 import React from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Button } from '~/components/atoms/Button';
 import { ResumeBasicInput } from '~/components/organisms/ResumeBasicInput';
 import { ActivityForm } from '~/components/organisms/ResumeCategoryActivity';
 import { AwardForm } from '~/components/organisms/ResumeCategoryAwards';
@@ -17,6 +18,7 @@ import {
   AwardDetails,
   ActivityDetails,
 } from '~/components/organisms/ResumeDetails';
+import { appPaths } from '~/config/paths';
 import useUser from '~/hooks/useUser';
 import { useGetResumeActivities } from '~/queries/resume/details/useGetResumeActivities';
 import { useGetResumeAward } from '~/queries/resume/details/useGetResumeAward';
@@ -39,6 +41,7 @@ const EditResumeTemplate = () => {
   const resumeAuthorId = basicInfo.ownerInfo?.id;
   const { user } = useUser();
   const isCurrentUser = resumeAuthorId === user?.id;
+  const navigate = useNavigate();
 
   return (
     <Flex
@@ -107,6 +110,13 @@ const EditResumeTemplate = () => {
           isCurrentUser={isCurrentUser}
         />
       </CategoryContainer>
+      <Button
+        alignSelf={'end'}
+        size={'md'}
+        onClick={() => navigate(appPaths.resumeDetail(parseInt(resumeId)))}
+      >
+        작성 완료
+      </Button>
     </Flex>
   );
 };

--- a/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
+++ b/src/components/templates/EditResumeTemplate/EditResumeTemplate.tsx
@@ -1,6 +1,6 @@
-import { Box, Flex } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import React from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { Button } from '~/components/atoms/Button';
 import { ResumeBasicInput } from '~/components/organisms/ResumeBasicInput';
 import { ActivityForm } from '~/components/organisms/ResumeCategoryActivity';
@@ -113,7 +113,7 @@ const EditResumeTemplate = () => {
       <Button
         alignSelf={'end'}
         size={'md'}
-        onClick={() => navigate(appPaths.resumeDetail(parseInt(resumeId)))}
+        onClick={() => navigate(appPaths.resumeDetail(parseInt(resumeId)), { replace: true })}
       >
         작성 완료
       </Button>


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
<img width="1006" alt="스크린샷 2023-12-01 오후 2 51 38" src="https://github.com/resumeme/Frontend/assets/91667853/67f6017b-b613-4cc0-a539-9eb27d5595ef">

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 이력서 작성 페이지에 작성 완료 버튼을 생성했습니다.
- 클릭하면 이력서 상세 페이지로 이동합니다.
- replace 옵션을 추가해서 상세 페이지로 이동 후 뒤로 가면 작성 페이지의 이전 페이지로 이동합니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
