### PR TITLE
Gmmq 779 fix: 401에러 처리 수정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,8 @@ import { createStandaloneToast } from '@chakra-ui/toast';
 import { QueryCache, QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { isAxiosError } from 'axios';
 import { RouterProvider } from 'react-router-dom';
-import { appPaths } from './config/paths';
 import CONSTANTS from './constants/index';
 import { ResumeMeErrorResponse } from './types/errorResponse';
-import { deleteCookie } from './utils/cookie';
 import router from '~/routes/router';
 import theme from '~/theme';
 import Fonts from '~/theme/typography/fonts';
@@ -19,15 +17,6 @@ const axiosErrorHandler = (error: Error) => {
     const { status } = error.response;
 
     switch (status) {
-      case 401:
-        deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
-        deleteCookie(CONSTANTS.REFRESH_TOKEN_HEADER);
-
-        alert(CONSTANTS.ERROR_MESSAGES[code]);
-
-        window.location.replace(appPaths.signIn());
-        break;
-
       default:
         if (!(code in CONSTANTS.ERROR_MESSAGES)) {
           return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ const axiosErrorHandler = (error: Error) => {
     const { status } = error.response;
 
     switch (status) {
-      default:
+      case 400:
         if (!(code in CONSTANTS.ERROR_MESSAGES)) {
           return;
         }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,6 +1,8 @@
 import axios from 'axios';
 import { environments } from '~/config/environments';
+import { appPaths } from '~/config/paths';
 import CONSTANTS from '~/constants';
+import { ErrorMessage } from '~/types/errorResponse';
 import { deleteCookie, getCookie, setCookie } from '~/utils/cookie';
 
 export const resumeMeAxios = axios.create({
@@ -26,7 +28,7 @@ resumeMeAxios.interceptors.response.use(
   },
   async function (error) {
     const statusCode = error.response.status;
-    const { code } = error.response.data;
+    const { code }: { code: ErrorMessage } = error.response.data;
 
     if (statusCode === 400 && code === 'INVALID_ACCESS_TOKEN') {
       deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
@@ -45,6 +47,15 @@ resumeMeAxios.interceptors.response.use(
       const newAccessToken = headers[CONSTANTS.ACCESS_TOKEN_HEADER];
 
       setCookie(CONSTANTS.ACCESS_TOKEN_HEADER, newAccessToken);
+    }
+
+    if (statusCode === 401) {
+      deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+      deleteCookie(CONSTANTS.REFRESH_TOKEN_HEADER);
+
+      alert(CONSTANTS.ERROR_MESSAGES[code]);
+
+      window.location.href = appPaths.signIn();
     }
 
     return Promise.reject(error);

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -50,12 +50,20 @@ resumeMeAxios.interceptors.response.use(
     }
 
     if (statusCode === 401) {
-      deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
-      deleteCookie(CONSTANTS.REFRESH_TOKEN_HEADER);
+      if (code === 'MENTOR_ALREADY_APPROVED') {
+        if (getCookie(CONSTANTS.ACCESS_TOKEN_HEADER)) {
+          deleteCookie(CONSTANTS.ACCESS_TOKEN_HEADER);
+          deleteCookie(CONSTANTS.REFRESH_TOKEN_HEADER);
 
-      alert(CONSTANTS.ERROR_MESSAGES[code]);
+          alert(CONSTANTS.ERROR_MESSAGES[code]);
 
-      window.location.href = appPaths.signIn();
+          window.location.href = appPaths.signIn();
+        }
+      } else {
+        alert(CONSTANTS.ERROR_MESSAGES.LOGIN_REQUIRED);
+
+        window.location.href = appPaths.signIn();
+      }
     }
 
     return Promise.reject(error);

--- a/src/constants/errorMessage.ts
+++ b/src/constants/errorMessage.ts
@@ -16,4 +16,5 @@ export const ERROR_MESSAGES = {
   GPA_ERROR: '최대 학점은 내 학점보다 커야 해요',
   MENTOR_NOT_FOUND: '멘토를 찾을 수 없어요 :(',
   NOT_UPDATE_EVENT: '모집 받는 중에는 수정할 수 없어요.',
+  MENTOR_ALREADY_APPROVED: '멘토로 승인되었어요. 다시 로그인 해주세요.',
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
401에러 발생 후 alert에서 확인 버튼을 누르면 에러 바운더리를 거치는 문제를 해결했습니다.
401에러에서 mentor 승인에 대한 code일 때 alert을 한번만 띄우도록 수정했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
