### PR TITLE
fix: 모든 페이지 이동 시 스크롤 위치 초기화

### DIFF
--- a/src/pages/ResumePages/FeedbackResumePage/FeedbackResumePage.tsx
+++ b/src/pages/ResumePages/FeedbackResumePage/FeedbackResumePage.tsx
@@ -1,13 +1,8 @@
 import { Box, Flex } from '@chakra-ui/react';
-import { useEffect } from 'react';
 import RemoteControlPannel from '~/components/organisms/RemoteControlPannel/RemoteControlPannel';
 import { FeedbackResumeTemplate } from '~/components/templates/FeedbackResumeTemplate';
 
 const FeedbackResumePage = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
   return (
     <Flex w={'full'}>
       <Box w={'900px'}>

--- a/src/pages/ResumePages/ResumeDetailPage/ResumeDetailPage.tsx
+++ b/src/pages/ResumePages/ResumeDetailPage/ResumeDetailPage.tsx
@@ -1,11 +1,6 @@
-import { useEffect } from 'react';
 import { ResumeDetailTemplate } from '~/components/templates/ResumeDetailTemplate';
 
 const ResumeDetailPage = () => {
-  useEffect(() => {
-    window.scrollTo(0, 0);
-  }, []);
-
   return <ResumeDetailTemplate />;
 };
 

--- a/src/routes/FocusLayout.tsx
+++ b/src/routes/FocusLayout.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex } from '@chakra-ui/react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
 
 const FocusLayout = () => {
   return (
@@ -8,6 +8,7 @@ const FocusLayout = () => {
       justifyContent={'center'}
       alignItems={'center'}
     >
+      <ScrollRestoration />
       <Box maxW={'992px'}>
         <Outlet />
       </Box>

--- a/src/routes/Layout.tsx
+++ b/src/routes/Layout.tsx
@@ -1,6 +1,7 @@
 import { Box } from '@chakra-ui/react';
 import { Suspense } from 'react';
 import { Outlet } from 'react-router-dom';
+import { ScrollRestoration } from 'react-router-dom';
 import { LAYOUT_SIZE } from './layoutSize.const';
 import { Spinner } from '~/components/atoms/Spinner';
 import { Footer } from '~/components/organisms/Footer';
@@ -15,6 +16,7 @@ const Layout = () => {
       flexDirection={'column'}
       overflowX={'hidden'}
     >
+      <ScrollRestoration />
       <Box
         position={'fixed'}
         zIndex={'sticky'}

--- a/src/routes/MainLayout.tsx
+++ b/src/routes/MainLayout.tsx
@@ -1,6 +1,6 @@
 import { Box } from '@chakra-ui/react';
 import { Suspense } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, ScrollRestoration } from 'react-router-dom';
 import { Spinner } from '~/components/atoms/Spinner';
 import { Footer } from '~/components/organisms/Footer';
 import { Header } from '~/components/organisms/Header';
@@ -14,6 +14,7 @@ const MainLayout = () => {
       flexDirection={'column'}
       overflowX={'hidden'}
     >
+      <ScrollRestoration />
       <Box
         position={'fixed'}
         zIndex={'sticky'}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 페이지 이동 시 스크롤 위치가 이전 페이지의 위치가 유지되는 문제가 있었습니다.
  - 그래서 각 페이지에서 useEffect 내에서 window객체로 조작해주고 있었는데, 생각해보니 웬만한 페이지들이 다 이게 필요하지 않나 싶더라고요.
- 스크롤 위치가 유지되는 게 장점으로 작용할 때도 있겠지만, 우선 아직까지는 저희 사이트에 그런 경우는 없는 것 같아 전체 레이아웃에 걸어주었습니다. 따라서 모든 페이지 이동 시 스크롤 위치가 최상단에서부터 시작합니다.
  - 예외 케이스들이 있을 것 같다면 알려주세요!
- react-router의 [ScrollRestoration](https://reactrouter.com/en/main/components/scroll-restoration)을 활용했습니다.
  - 페이지 이동하고 나면 스크롤 위치가 제 자리로 돌아가도록 해주는 컴포넌트라고 합니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
