### PR TITLE
refactor: mutate 함수 alias 변수명 통일

### DIFF
--- a/src/components/molecules/FeedbackView/FeedbackView.tsx
+++ b/src/components/molecules/FeedbackView/FeedbackView.tsx
@@ -38,8 +38,8 @@ const FeedbackView = ({
   const [isEdit, setIsEdit] = useState<boolean>(false);
   const [value, setValue] = useState<string | undefined>(content);
   const { resumeId = '', eventId = '' } = useParams();
-  const { mutate: patchCommentMutate } = usePatchFeedbackComment(resumeId, eventId);
-  const { mutate: deleteCommentMutate } = useDeleteFeedbackComment(resumeId, eventId);
+  const { mutate: patchComment } = usePatchFeedbackComment(resumeId, eventId);
+  const { mutate: deleteComment } = useDeleteFeedbackComment(resumeId, eventId);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
 
@@ -62,7 +62,7 @@ const FeedbackView = ({
       const body = {
         content: value,
       };
-      patchCommentMutate(
+      patchComment(
         { resumeId, eventId, commentId, body },
         {
           onSuccess: () => {
@@ -76,7 +76,7 @@ const FeedbackView = ({
 
   const handleRemove = () => {
     if (resumeId && eventId && commentId) {
-      deleteCommentMutate({ resumeId, eventId, commentId });
+      deleteComment({ resumeId, eventId, commentId });
     }
   };
 

--- a/src/components/molecules/MentorProfile/MentorProfile.tsx
+++ b/src/components/molecules/MentorProfile/MentorProfile.tsx
@@ -55,7 +55,7 @@ const MentorProfile = ({
   };
   const { data: followData } = useGetMentorFollow({ mentorId, role: user?.role });
   const { mutate: deleteMentorFollow } = useDeleteMentorFollow();
-  const { mutate: mentorFollow } = usePostMentorFollow();
+  const { mutate: postMentorFollow } = usePostMentorFollow();
 
   return (
     <>
@@ -159,7 +159,7 @@ const MentorProfile = ({
                 onClick={
                   followData?.id
                     ? () => deleteMentorFollow({ followId: Number(followData?.id) })
-                    : () => mentorFollow({ mentorId })
+                    : () => postMentorFollow({ mentorId })
                 }
                 _hover={{
                   bg: 'gray.300',

--- a/src/components/organisms/Header/Header.tsx
+++ b/src/components/organisms/Header/Header.tsx
@@ -100,7 +100,7 @@ const Navigation = ({ user }: { user: User | null }) => {
 
 const Header = () => {
   const { user } = useUser();
-  const { mutate: signOut } = usePostSignOut();
+  const { mutate: postSignOut } = usePostSignOut();
 
   const navigate = useNavigate();
 
@@ -111,14 +111,14 @@ const Header = () => {
       onClick: () => navigate(appPaths.eventCreate()),
     },
     { text: TEXT_CONTENTS.EDIT_PROFILE, onClick: () => navigate(appPaths.userEditInfo()) },
-    { text: TEXT_CONTENTS.SIGN_OUT, onClick: signOut },
+    { text: TEXT_CONTENTS.SIGN_OUT, onClick: postSignOut },
   ];
 
   const menteeOptions: Option[] = [
     { text: TEXT_CONTENTS.MY_PAGE, onClick: () => navigate(appPaths.myPage()) },
     { text: TEXT_CONTENTS.RESUME, onClick: () => navigate(appPaths.managementResume()) },
     { text: TEXT_CONTENTS.EDIT_PROFILE, onClick: () => navigate(appPaths.userEditInfo()) },
-    { text: TEXT_CONTENTS.SIGN_OUT, onClick: signOut },
+    { text: TEXT_CONTENTS.SIGN_OUT, onClick: postSignOut },
   ];
 
   return (

--- a/src/components/organisms/RemoteControlPannel/RejectionModalContent.tsx
+++ b/src/components/organisms/RemoteControlPannel/RejectionModalContent.tsx
@@ -12,7 +12,7 @@ type RejectionModalContentProps = {
 };
 
 const RejectionModalContent = ({ onClose, eventId, menteeId }: RejectionModalContentProps) => {
-  const { mutate: patchRejectMutate } = usePatchFeedbackReject();
+  const { mutate: patchFeedbackReject } = usePatchFeedbackReject();
 
   const {
     register,
@@ -23,7 +23,7 @@ const RejectionModalContent = ({ onClose, eventId, menteeId }: RejectionModalCon
   const onSubmit = (value: EventReject) => {
     value.menteeId = menteeId;
 
-    patchRejectMutate({ eventId, body: value });
+    patchFeedbackReject({ eventId, body: value });
 
     if (onClose) {
       onClose();

--- a/src/components/organisms/RemoteControlPannel/RejectionModalContent.tsx
+++ b/src/components/organisms/RemoteControlPannel/RejectionModalContent.tsx
@@ -12,7 +12,7 @@ type RejectionModalContentProps = {
 };
 
 const RejectionModalContent = ({ onClose, eventId, menteeId }: RejectionModalContentProps) => {
-  const { mutate } = usePatchFeedbackReject();
+  const { mutate: patchRejectMutate } = usePatchFeedbackReject();
 
   const {
     register,
@@ -23,7 +23,7 @@ const RejectionModalContent = ({ onClose, eventId, menteeId }: RejectionModalCon
   const onSubmit = (value: EventReject) => {
     value.menteeId = menteeId;
 
-    mutate({ eventId, body: value });
+    patchRejectMutate({ eventId, body: value });
 
     if (onClose) {
       onClose();

--- a/src/components/organisms/RemoteControlPannel/RemoteControlPannel.tsx
+++ b/src/components/organisms/RemoteControlPannel/RemoteControlPannel.tsx
@@ -15,7 +15,7 @@ const RemoteControlPannel = () => {
   const { eventId = '', resumeId = '' } = useParams();
   const { data } = useGetResumeBasic({ resumeId });
   const menteeId = data?.ownerInfo?.id as number;
-  const { mutate } = usePatchFeedbackComplete();
+  const { mutate: patchCompleteMutate } = usePatchFeedbackComplete();
   const navigate = useNavigate();
 
   const {
@@ -28,7 +28,7 @@ const RemoteControlPannel = () => {
     if (eventId !== '' && resumeId !== '') {
       value.resumeId = Number(resumeId);
 
-      mutate(
+      patchCompleteMutate(
         { eventId, body: value },
         {
           onSuccess: () =>

--- a/src/components/organisms/RemoteControlPannel/RemoteControlPannel.tsx
+++ b/src/components/organisms/RemoteControlPannel/RemoteControlPannel.tsx
@@ -15,7 +15,7 @@ const RemoteControlPannel = () => {
   const { eventId = '', resumeId = '' } = useParams();
   const { data } = useGetResumeBasic({ resumeId });
   const menteeId = data?.ownerInfo?.id as number;
-  const { mutate: patchCompleteMutate } = usePatchFeedbackComplete();
+  const { mutate: patchFeedbackComplete } = usePatchFeedbackComplete();
   const navigate = useNavigate();
 
   const {
@@ -28,7 +28,7 @@ const RemoteControlPannel = () => {
     if (eventId !== '' && resumeId !== '') {
       value.resumeId = Number(resumeId);
 
-      patchCompleteMutate(
+      patchFeedbackComplete(
         { eventId, body: value },
         {
           onSuccess: () =>

--- a/src/components/organisms/ResumeBasicInput/ReferenceLinkForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/ReferenceLinkForm.tsx
@@ -15,8 +15,8 @@ type ReferenceLinkFormProps = {
 };
 
 const ReferenceLinkForm = ({ defaultValue, resumeId }: ReferenceLinkFormProps) => {
-  const { mutate: postReferenceLinkMutate } = usePostResumeLink(resumeId);
-  const { mutate: deleteReferenceLinkMutate } = useDeleteReferenceLink(resumeId);
+  const { mutate: postReferenceLink } = usePostResumeLink(resumeId);
+  const { mutate: deleteReferenceLink } = useDeleteReferenceLink(resumeId);
   const {
     register,
     handleSubmit,
@@ -33,12 +33,12 @@ const ReferenceLinkForm = ({ defaultValue, resumeId }: ReferenceLinkFormProps) =
       return;
     }
 
-    postReferenceLinkMutate({ resumeId, body });
+    postReferenceLink({ resumeId, body });
     reset();
   });
 
   const handleRemoveLink = (componentId: number) => {
-    deleteReferenceLinkMutate({ resumeId, linkId: componentId });
+    deleteReferenceLink({ resumeId, linkId: componentId });
   };
   return (
     <>

--- a/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
@@ -56,7 +56,7 @@ type TitleInputFormProps = {
 
 const TitleInputForm = ({ defaultValue }: TitleInputFormProps) => {
   const { resumeId } = useParams();
-  const { mutate: patchResumeTitleMutate, isPending, isSuccess, isError } = usePatchResumeTitle();
+  const { mutate: patchResumeTitle, isPending, isSuccess, isError } = usePatchResumeTitle();
   const navigate = useNavigate();
   const [empty, setEmpty] = useState(false);
 
@@ -87,7 +87,7 @@ const TitleInputForm = ({ defaultValue }: TitleInputFormProps) => {
       } else {
         setEmpty(false);
       }
-      patchResumeTitleMutate({ resumeId, resumeTitle });
+      patchResumeTitle({ resumeId, resumeTitle });
     }, 1000);
   };
 

--- a/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
+++ b/src/components/organisms/ResumeBasicInput/TitleInputForm.tsx
@@ -56,7 +56,7 @@ type TitleInputFormProps = {
 
 const TitleInputForm = ({ defaultValue }: TitleInputFormProps) => {
   const { resumeId } = useParams();
-  const { mutate, isPending, isSuccess, isError } = usePatchResumeTitle();
+  const { mutate: patchResumeTitleMutate, isPending, isSuccess, isError } = usePatchResumeTitle();
   const navigate = useNavigate();
   const [empty, setEmpty] = useState(false);
 
@@ -87,7 +87,7 @@ const TitleInputForm = ({ defaultValue }: TitleInputFormProps) => {
       } else {
         setEmpty(false);
       }
-      mutate({ resumeId, resumeTitle });
+      patchResumeTitleMutate({ resumeId, resumeTitle });
     }, 1000);
   };
 

--- a/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
+++ b/src/components/organisms/ResumeCategoryActivity/ActivityForm.tsx
@@ -42,12 +42,12 @@ const ActivityForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postActivityMutate } = useOptimisticPostCategory({
+  const { mutate: postActivity } = useOptimisticPostCategory({
     mutationFn: postResumeActivity,
     TARGET_QUERY_KEY: categoryKeys.activity(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchResumeActivityMutate } = useOptimisticPatchCategory({
+  const { mutate: patchActivity } = useOptimisticPatchCategory({
     mutationFn: patchResumeActivity,
     TARGET_QUERY_KEY: categoryKeys.activity(resumeId),
     onMutateSuccess: quitEdit,
@@ -58,9 +58,9 @@ const ActivityForm = ({
       return;
     }
     if (!isEdit) {
-      postActivityMutate({ resumeId, body });
+      postActivity({ resumeId, body });
     } else if (isEdit && blockId) {
-      patchResumeActivityMutate({ resumeId, blockId, body });
+      patchActivity({ resumeId, blockId, body });
     }
   };
 

--- a/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
+++ b/src/components/organisms/ResumeCategoryAwards/AwardForm.tsx
@@ -39,12 +39,12 @@ const AwardForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postAwardMutate } = useOptimisticPostCategory({
+  const { mutate: postAward } = useOptimisticPostCategory({
     mutationFn: postResumeAward,
     TARGET_QUERY_KEY: categoryKeys.award(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchResumeAwardMutate } = useOptimisticPatchCategory({
+  const { mutate: patchAward } = useOptimisticPatchCategory({
     mutationFn: patchResumeAward,
     TARGET_QUERY_KEY: categoryKeys.award(resumeId),
     onMutateSuccess: quitEdit,
@@ -55,9 +55,9 @@ const AwardForm = ({
       return;
     }
     if (!isEdit) {
-      postAwardMutate({ resumeId, body });
+      postAward({ resumeId, body });
     } else if (isEdit && blockId) {
-      patchResumeAwardMutate({ resumeId, blockId, body });
+      patchAward({ resumeId, blockId, body });
     }
   };
 

--- a/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
+++ b/src/components/organisms/ResumeCategoryCareer/CareerForm.tsx
@@ -67,12 +67,12 @@ const CareerForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postCareerMutate } = useOptimisticPostCategory({
+  const { mutate: postCareer } = useOptimisticPostCategory({
     mutationFn: postResumeCareer,
     TARGET_QUERY_KEY: categoryKeys.career(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchCareerMutate } = useOptimisticPatchCategory({
+  const { mutate: patchCareer } = useOptimisticPatchCategory({
     mutationFn: patchResumeCareer,
     TARGET_QUERY_KEY: categoryKeys.career(resumeId),
     onMutateSuccess: quitEdit,
@@ -102,14 +102,14 @@ const CareerForm = ({
       removeDuties();
     };
     if (!isEdit) {
-      postCareerMutate(
+      postCareer(
         { resumeId, body },
         {
           onSuccess: initializeForm,
         },
       );
     } else if (isEdit && blockId) {
-      patchCareerMutate(
+      patchCareer(
         { resumeId, blockId, body },
         {
           onSuccess: initializeForm,

--- a/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
+++ b/src/components/organisms/ResumeCategoryLanguage/LanguageForm.tsx
@@ -36,12 +36,12 @@ const LanguageForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postLanguageMutate } = useOptimisticPostCategory({
+  const { mutate: postLanguage } = useOptimisticPostCategory({
     mutationFn: postResumeLanguage,
     TARGET_QUERY_KEY: categoryKeys.language(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchResumeLanguageMutate } = useOptimisticPatchCategory({
+  const { mutate: patchLanguage } = useOptimisticPatchCategory({
     mutationFn: patchResumeLanguage,
     TARGET_QUERY_KEY: categoryKeys.language(resumeId),
     onMutateSuccess: quitEdit,
@@ -52,9 +52,9 @@ const LanguageForm = ({
       return;
     }
     if (!isEdit) {
-      postLanguageMutate({ resumeId, body });
+      postLanguage({ resumeId, body });
     } else if (isEdit && blockId) {
-      patchResumeLanguageMutate({ resumeId, blockId, body });
+      patchLanguage({ resumeId, blockId, body });
     }
   };
 

--- a/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
+++ b/src/components/organisms/ResumeCategoryProject/ProjectForm.tsx
@@ -43,12 +43,12 @@ const ProjectForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postProjectMutate } = useOptimisticPostCategory({
+  const { mutate: postProject } = useOptimisticPostCategory({
     mutationFn: postResumeProject,
     TARGET_QUERY_KEY: categoryKeys.project(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchResumeProjectMutate } = useOptimisticPatchCategory({
+  const { mutate: patchProject } = useOptimisticPatchCategory({
     mutationFn: patchResumeProject,
     TARGET_QUERY_KEY: categoryKeys.project(resumeId),
     onMutateSuccess: quitEdit,
@@ -65,14 +65,14 @@ const ProjectForm = ({
     body.skills = skills;
     body.team = Boolean(body.team);
     if (!isEdit) {
-      postProjectMutate(
+      postProject(
         { resumeId, body },
         {
           onSuccess: initializeSkills,
         },
       );
     } else if (isEdit && blockId) {
-      patchResumeProjectMutate(
+      patchProject(
         { resumeId, blockId, body },
         {
           onSuccess: initializeSkills,

--- a/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
+++ b/src/components/organisms/ResumeCategoryTraining/TrainingForm.tsx
@@ -39,12 +39,12 @@ const TrainingForm = ({
   const { isOpen, onClose, showForm, setShowForm, handleCancel, handleDeleteForm } =
     useHandleFormState(isDirty, reset);
 
-  const { mutate: postTrainingMutate } = useOptimisticPostCategory({
+  const { mutate: postTraining } = useOptimisticPostCategory({
     mutationFn: postResumeTraining,
     TARGET_QUERY_KEY: categoryKeys.training(resumeId),
     onMutateSuccess: handleDeleteForm,
   });
-  const { mutate: patchResumeTrainingMutate } = useOptimisticPatchCategory({
+  const { mutate: patchTraining } = useOptimisticPatchCategory({
     mutationFn: patchResumeTraining,
     TARGET_QUERY_KEY: categoryKeys.training(resumeId),
     onMutateSuccess: quitEdit,
@@ -55,9 +55,9 @@ const TrainingForm = ({
       return;
     }
     if (!isEdit) {
-      postTrainingMutate({ resumeId, body });
+      postTraining({ resumeId, body });
     } else if (isEdit && blockId) {
-      patchResumeTrainingMutate({ resumeId, blockId, body });
+      patchTraining({ resumeId, blockId, body });
     }
   };
 

--- a/src/components/organisms/ResumeDetails/ActivityDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ActivityDetails.tsx
@@ -16,7 +16,7 @@ const ActivityDetails = ({
 }: DetailsComponentProps<ReadActivity>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Activity, ReadActivity>({
+  const { mutate: deleteCategory } = useOptimisticDeleteCategory<Activity, ReadActivity>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.activity(resumeId),
   });
@@ -95,7 +95,7 @@ const ActivityDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteMutate({ resumeId, blockId })}
+          onDelete={() => deleteCategory({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeDetails/CareerDetails.tsx
+++ b/src/components/organisms/ResumeDetails/CareerDetails.tsx
@@ -26,7 +26,7 @@ const CareerDetails = ({
 }: DetailsComponentProps<ReadCareer>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Career, ReadCareer>({
+  const { mutate: deleteCategory } = useOptimisticDeleteCategory<Career, ReadCareer>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.career(resumeId),
   });
@@ -149,7 +149,7 @@ const CareerDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteMutate({ resumeId, blockId })}
+          onDelete={() => deleteCategory({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeDetails/LanguageDetails.tsx
+++ b/src/components/organisms/ResumeDetails/LanguageDetails.tsx
@@ -15,7 +15,7 @@ const LanguageDetails = ({
 }: DetailsComponentProps<ReadLanguage>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Language, ReadLanguage>({
+  const { mutate: deleteCategory } = useOptimisticDeleteCategory<Language, ReadLanguage>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.language(resumeId),
   });
@@ -62,7 +62,7 @@ const LanguageDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteMutate({ resumeId, blockId })}
+          onDelete={() => deleteCategory({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeDetails/ProjectDetails.tsx
+++ b/src/components/organisms/ResumeDetails/ProjectDetails.tsx
@@ -25,7 +25,7 @@ const ProjectDetails = ({
 }: DetailsComponentProps<ReadProject>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Project, ReadProject>({
+  const { mutate: deleteCategory } = useOptimisticDeleteCategory<Project, ReadProject>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.project(resumeId),
   });
@@ -133,7 +133,7 @@ const ProjectDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteMutate({ resumeId, blockId })}
+          onDelete={() => deleteCategory({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeDetails/TrainingDetails.tsx
+++ b/src/components/organisms/ResumeDetails/TrainingDetails.tsx
@@ -25,7 +25,7 @@ const TraningDetails = ({
 }: DetailsComponentProps<ReadTraining>) => {
   const { resumeId = '' } = useParams();
   const blockId = componentId;
-  const { mutate: deleteMutate } = useOptimisticDeleteCategory<Training, ReadTraining>({
+  const { mutate: deleteCategory } = useOptimisticDeleteCategory<Training, ReadTraining>({
     mutationFn: deleteResumeCategoryBlock,
     TARGET_QUERY_KEY: categoryKeys.training(resumeId),
   });
@@ -135,7 +135,7 @@ const TraningDetails = ({
       {isCurrentUser && (
         <EditDeleteOptionsButton
           onEdit={onEdit}
-          onDelete={() => deleteMutate({ resumeId, blockId })}
+          onDelete={() => deleteCategory({ resumeId, blockId })}
         />
       )}
     </Flex>

--- a/src/components/organisms/ResumeNavigator/ResumeNavigator.tsx
+++ b/src/components/organisms/ResumeNavigator/ResumeNavigator.tsx
@@ -21,7 +21,7 @@ type ButtonInfo = {
 };
 
 const ResumeNavigator = ({ pageStep, onStep }: ResumeNavigatorProps) => {
-  const { mutate: createResume } = usePostCreateResume();
+  const { mutate: postCreateResume } = usePostCreateResume();
 
   const BUTTONS_INFO: ButtonInfo[] = [
     {
@@ -39,7 +39,7 @@ const ResumeNavigator = ({ pageStep, onStep }: ResumeNavigatorProps) => {
     {
       text: '새 이력서',
       icon: MdPostAdd,
-      onClick: createResume,
+      onClick: postCreateResume,
     },
   ];
 

--- a/src/components/organisms/ResumeSelect/ResumeSelect.tsx
+++ b/src/components/organisms/ResumeSelect/ResumeSelect.tsx
@@ -13,7 +13,7 @@ type ResumeSelectProps = {
 };
 const ResumeSelect = ({ onCancel, onSubmit }: ResumeSelectProps) => {
   const { data } = useGetMyResumes();
-  const { mutate: postCreateResumeMutate } = usePostCreateResume();
+  const { mutate: postCreateResume } = usePostCreateResume();
   const { register, handleSubmit } = useForm<{ resumeId: string }>();
   return (
     <>
@@ -52,7 +52,7 @@ const ResumeSelect = ({ onCancel, onSubmit }: ResumeSelectProps) => {
                   </Text>
                   <Button
                     size={'md'}
-                    onClick={() => postCreateResumeMutate()}
+                    onClick={() => postCreateResume()}
                   >
                     이력서 작성하러 가기
                   </Button>

--- a/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
+++ b/src/components/templates/FeedbackReflectTemplate/FeedbackReflectTemplate.tsx
@@ -57,7 +57,7 @@ const FeedbackReflectTemplate = () => {
 
   const { data: mentorData } = useGetMentorDetail({ mentorId });
 
-  const { mutate: patchReflectCompleteMutate } = usePatchFeedbackReflectComplete();
+  const { mutate: patchReflectComplete } = usePatchFeedbackReflectComplete();
   const navigate = useNavigate();
   return (
     <Flex
@@ -147,7 +147,7 @@ const FeedbackReflectTemplate = () => {
 
       <Button
         onClick={() =>
-          patchReflectCompleteMutate(
+          patchReflectComplete(
             { resumeId },
             {
               onSuccess: () => {

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
@@ -13,7 +13,7 @@ const LABEL_TEXT = '피드백하기';
 
 const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
   const { eventId = '', resumeId = '' } = useParams();
-  const { mutate: postCommentMutate } = usePostFeedbackComment(resumeId, eventId);
+  const { mutate: postFeedbackComment } = usePostFeedbackComment(resumeId, eventId);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [value, setValue] = useState<string>('');
 
@@ -29,7 +29,7 @@ const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
       content: value,
     };
 
-    postCommentMutate(
+    postFeedbackComment(
       { eventId, resumeId, body },
       {
         onSuccess: () => {

--- a/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
+++ b/src/components/templates/FeedbackResumeTemplate/FeedbackBlock.tsx
@@ -13,7 +13,7 @@ const LABEL_TEXT = '피드백하기';
 
 const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
   const { eventId = '', resumeId = '' } = useParams();
-  const { mutate } = usePostFeedbackComment(resumeId, eventId);
+  const { mutate: postCommentMutate } = usePostFeedbackComment(resumeId, eventId);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const [value, setValue] = useState<string>('');
 
@@ -29,7 +29,7 @@ const FeedbackBlock = ({ blockId }: FeedbackBlockProps) => {
       content: value,
     };
 
-    mutate(
+    postCommentMutate(
       { eventId, resumeId, body },
       {
         onSuccess: () => {

--- a/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
+++ b/src/components/templates/ResumeDetailTemplate/ResumeDetailTemplate.tsx
@@ -27,7 +27,7 @@ const ResumeDetailTemplate = () => {
 
   const { data: details } = useGetResumeDetails({ resumeId });
   const { data: basicInfo } = useGetResumeBasic({ resumeId });
-  const { mutate: deleteResumeMutate } = useDeleteResume();
+  const { mutate: deleteResume } = useDeleteResume();
 
   const navigate = useNavigate();
 
@@ -70,7 +70,7 @@ const ResumeDetailTemplate = () => {
           <EditDeleteOptionsButton
             onEdit={() => navigate(appPaths.resumeEdit(parseInt(resumeId)))}
             onDelete={() =>
-              deleteResumeMutate(
+              deleteResume(
                 { resumeId },
                 {
                   onSuccess: () => navigate(appPaths.managementResume()),

--- a/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
+++ b/src/pages/EventPages/EventDetailPage/EventDetailPage.tsx
@@ -26,7 +26,7 @@ const EventDetailPage = () => {
 
   const { data: event } = useGetEventDetail({ eventId });
   const { data: mentor } = useGetMentorDetail({ mentorId: String(event.mentorId) });
-  const { mutate: postEventApplyMutate } = usePostEventApply();
+  const { mutate: postEventApply } = usePostEventApply();
 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const queryClient = useQueryClient();
@@ -45,7 +45,7 @@ const EventDetailPage = () => {
           <ResumeSelect
             onCancel={onClose}
             onSubmit={({ resumeId }) => {
-              postEventApplyMutate(
+              postEventApply(
                 { resumeId: parseInt(resumeId), eventId },
                 {
                   onSettled: () => {

--- a/src/pages/MainPage/MainPage.tsx
+++ b/src/pages/MainPage/MainPage.tsx
@@ -30,7 +30,7 @@ const MainPage = () => {
     data: { events },
   } = useGetEventList({ page: 1, size: 4 });
 
-  const { mutate: createResume } = usePostCreateResume();
+  const { mutate: postCreateResume } = usePostCreateResume();
 
   const navigate = useNavigate();
 
@@ -48,7 +48,7 @@ const MainPage = () => {
   const menteeButton: Option[] = [
     {
       text: '새 이력서 작성',
-      onClick: createResume,
+      onClick: postCreateResume,
     },
     {
       text: '이력서 관리',

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -34,7 +34,7 @@ const OAuthRedirectPage = () => {
     return;
   };
 
-  const { mutate: signInMutate } = usePostOAuthSignIn();
+  const { mutate: postSignInMutate } = usePostOAuthSignIn();
 
   useEffect(() => {
     if (!code) {
@@ -46,7 +46,7 @@ const OAuthRedirectPage = () => {
       navigate(appPaths.signIn());
       return;
     }
-    signInMutate(
+    postSignInMutate(
       { loginProvider: 'kakao', code },
       {
         onSuccess: ({ cacheKey, accessToken, refreshToken }) => {

--- a/src/pages/SignInPage/OAuthRedirectPage.tsx
+++ b/src/pages/SignInPage/OAuthRedirectPage.tsx
@@ -34,7 +34,7 @@ const OAuthRedirectPage = () => {
     return;
   };
 
-  const { mutate: postSignInMutate } = usePostOAuthSignIn();
+  const { mutate: postSignIn } = usePostOAuthSignIn();
 
   useEffect(() => {
     if (!code) {
@@ -46,7 +46,7 @@ const OAuthRedirectPage = () => {
       navigate(appPaths.signIn());
       return;
     }
-    postSignInMutate(
+    postSignIn(
       { loginProvider: 'kakao', code },
       {
         onSuccess: ({ cacheKey, accessToken, refreshToken }) => {

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -14,7 +14,7 @@ import { SignUpRole, SignUpCommon } from '~/types/signUp';
 export type Step = 'COMMON' | SignUpRole | 'MENTOR_COMPLETE' | 'MENTEE_COMPLETE';
 
 const SignUpPage = () => {
-  const { mutate: signUpMutate } = usePostOAuthSignUp();
+  const { mutate: postSignUpMutate } = usePostOAuthSignUp();
   const [step, setStep] = useState<Step>('COMMON');
   const [commonData, setCommonData] = useState<SignUpCommon>();
   const cacheKey = useCacheKeyStore((state) => state.cacheKey);
@@ -80,7 +80,7 @@ const SignUpPage = () => {
               setStep('COMMON');
               return;
             }
-            signUpMutate(
+            postSignUpMutate(
               { body: { ...data, requiredInfo: commonData, cacheKey }, role: 'pending' },
               {
                 onSuccess: signUpSuccessCallback,
@@ -97,7 +97,7 @@ const SignUpPage = () => {
               setStep('COMMON');
               return;
             }
-            signUpMutate(
+            postSignUpMutate(
               { body: { ...data, requiredInfo: commonData, cacheKey }, role: 'mentee' },
               {
                 onSuccess: signUpSuccessCallback,

--- a/src/pages/SignUpPage/SignUpPage.tsx
+++ b/src/pages/SignUpPage/SignUpPage.tsx
@@ -14,7 +14,7 @@ import { SignUpRole, SignUpCommon } from '~/types/signUp';
 export type Step = 'COMMON' | SignUpRole | 'MENTOR_COMPLETE' | 'MENTEE_COMPLETE';
 
 const SignUpPage = () => {
-  const { mutate: postSignUpMutate } = usePostOAuthSignUp();
+  const { mutate: postSignUp } = usePostOAuthSignUp();
   const [step, setStep] = useState<Step>('COMMON');
   const [commonData, setCommonData] = useState<SignUpCommon>();
   const cacheKey = useCacheKeyStore((state) => state.cacheKey);
@@ -80,7 +80,7 @@ const SignUpPage = () => {
               setStep('COMMON');
               return;
             }
-            postSignUpMutate(
+            postSignUp(
               { body: { ...data, requiredInfo: commonData, cacheKey }, role: 'pending' },
               {
                 onSuccess: signUpSuccessCallback,
@@ -97,7 +97,7 @@ const SignUpPage = () => {
               setStep('COMMON');
               return;
             }
-            postSignUpMutate(
+            postSignUp(
               { body: { ...data, requiredInfo: commonData, cacheKey }, role: 'mentee' },
               {
                 onSuccess: signUpSuccessCallback,

--- a/src/queries/resume/create/usePatchResumeTitle.ts
+++ b/src/queries/resume/create/usePatchResumeTitle.ts
@@ -2,10 +2,8 @@ import { useMutation } from '@tanstack/react-query';
 import { patchResumeTitle } from '~/api/resume/create/patchResumeTitle';
 
 export const usePatchResumeTitle = () => {
-  const { mutate, isPending, isError, isSuccess } = useMutation({
+  return useMutation({
     mutationKey: ['patchTitle'],
     mutationFn: patchResumeTitle,
   });
-
-  return { mutate, isPending, isError, isSuccess };
 };

--- a/src/queries/resume/create/usePostResumeLink.ts
+++ b/src/queries/resume/create/usePostResumeLink.ts
@@ -9,7 +9,7 @@ export const usePostResumeLink = (resumeId: string) => {
   const TARGET_QUERY_KEY = resumeDetailKeys.referenceLinks(resumeId);
   const toast = useToast();
 
-  const { mutate, isPending, isError, isSuccess } = useMutation({
+  return useMutation({
     mutationFn: postResumeLink,
     onMutate: async (newReferenceLinks) => {
       await queryClient.cancelQueries({ queryKey: TARGET_QUERY_KEY });
@@ -33,6 +33,4 @@ export const usePostResumeLink = (resumeId: string) => {
       queryClient.invalidateQueries({ queryKey: TARGET_QUERY_KEY });
     },
   });
-
-  return { mutate, isPending, isError, isSuccess };
 };


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- 변수명을 `method 접두사 + mutation 이름`으로 통일했습니다.
- useMutation 함수 파일에서는 useMutation 자체를 return하고, mutate 등은 사용하는 곳에서 디스트럭처링하도록 통일했습니다. ([599ee79](https://github.com/resumeme/Frontend/commit/599ee7964b7aec85810ad077966732bbe9c35a76))
- 모든 useMutation의 mutate함수는 alias를 사용하도록 통일했습니다.

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
