### PR TITLE
fix: 이벤트 중복 출력 문제 해결

### DIFF
--- a/src/components/organisms/EventGrid/EventGrid.tsx
+++ b/src/components/organisms/EventGrid/EventGrid.tsx
@@ -1,4 +1,5 @@
 import { Grid, GridItem } from '@chakra-ui/react';
+import { v4 as uuidv4 } from 'uuid';
 import { EventGridItem } from '~/components/molecules/EventGridItem';
 import { EventListItem } from '~/types/event/eventList';
 
@@ -17,7 +18,7 @@ const EventGrid = ({ row = 3, events }: EventIdProps) => {
         gap={'2rem'}
       >
         {events.map((eventItem) => (
-          <GridItem key={eventItem.info.id}>
+          <GridItem key={uuidv4()}>
             <EventGridItem event={eventItem} />
           </GridItem>
         ))}


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/86753969/e2f3cd17-725b-40d4-94d9-c946a7a03b7a)
![image](https://github.com/resumeme/Frontend/assets/86753969/dc47e05e-c69f-4dc2-b975-9b471a77e940)


## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
페이지 네이션 후에 이벤트가 중복해서 출력되던 부분을 수정했습니다.

이벤트의 아이디를 받아서 키 값으로 지정해줬었는데, 받아오는 아이디들이 중복되는게 있어서 페이지를 이동하면 이상하게 출력되고 있었습니다.
uuid를 적용했습니다.
## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
