### PR TITLE
refactor: 테스트 로그인 버튼 컴포넌트 구현 및 로그인 페이지에 추가

### DIFF
--- a/src/components/molecules/TestSignInButton/TestSignInButton.tsx
+++ b/src/components/molecules/TestSignInButton/TestSignInButton.tsx
@@ -1,0 +1,70 @@
+import { Box, Image, Text } from '@chakra-ui/react';
+import { BorderBox } from '~/components/atoms/BorderBox';
+import { assets } from '~/config/assets';
+
+type TestSignInButtonProps = {
+  logo: 'mentee' | 'mentor';
+  onClick: VoidFunction;
+};
+
+const TestSignInButton = ({ logo, onClick }: TestSignInButtonProps) => {
+  const PLATFORMS = {
+    mentee: {
+      svg: assets.menteeSvg,
+      text: '멘티',
+    },
+    mentor: {
+      svg: assets.mentorSvg,
+      text: '멘토',
+    },
+  };
+
+  return (
+    <button onClick={onClick}>
+      <BorderBox
+        w={'5.8rem'}
+        h={'8rem'}
+        display={'flex'}
+        flexDirection="column"
+        gap={'0.7rem'}
+        justifyContent={'center'}
+        alignItems={'center'}
+        position={'relative'}
+      >
+        <Box
+          bgColor={'primary.900'}
+          borderTopRightRadius={'0.5rem'}
+          borderBottomLeftRadius={'0.5rem'}
+          borderBottomRightRadius={'2rem'}
+          w={'auto'}
+          h={'1.5rem'}
+          paddingX={'0.5rem'}
+          pr={'0.7rem'}
+          textColor={'white'}
+          borderColor={'primary.900'}
+          position="absolute"
+          top={'-0.3'}
+          right={'-2'}
+          zIndex={1}
+          gap={0}
+        >
+          <Text
+            textAlign={'center'}
+            fontWeight={'black'}
+            fontSize={'sm'}
+            color={'gray.100'}
+          >
+            TEST
+          </Text>
+        </Box>
+        <Image
+          src={PLATFORMS[logo].svg}
+          alt={PLATFORMS[logo].text}
+        />
+        <Box as="span">{PLATFORMS[logo].text}</Box>
+      </BorderBox>
+    </button>
+  );
+};
+
+export default TestSignInButton;

--- a/src/components/molecules/TestSignInButton/TestSignInButton.tsx
+++ b/src/components/molecules/TestSignInButton/TestSignInButton.tsx
@@ -8,7 +8,7 @@ type TestSignInButtonProps = {
 };
 
 const TestSignInButton = ({ logo, onClick }: TestSignInButtonProps) => {
-  const PLATFORMS = {
+  const LOGOS = {
     mentee: {
       svg: assets.menteeSvg,
       text: '멘티',
@@ -32,36 +32,30 @@ const TestSignInButton = ({ logo, onClick }: TestSignInButtonProps) => {
         position={'relative'}
       >
         <Box
-          bgColor={'primary.900'}
-          borderTopRightRadius={'0.5rem'}
-          borderBottomLeftRadius={'0.5rem'}
-          borderBottomRightRadius={'2rem'}
           w={'auto'}
-          h={'1.5rem'}
-          paddingX={'0.5rem'}
-          pr={'0.7rem'}
-          textColor={'white'}
-          borderColor={'primary.900'}
-          position="absolute"
-          top={'-0.3'}
-          right={'-2'}
+          h={'1.2rem'}
           zIndex={1}
-          gap={0}
+          bgColor={'gray.900'}
+          position="absolute"
+          top={'0'}
+          right={'-3'}
+          borderLeftRadius={'0.2rem'}
+          paddingLeft={'0.4rem'}
+          paddingRight={'0.6rem'}
         >
           <Text
-            textAlign={'center'}
-            fontWeight={'black'}
-            fontSize={'sm'}
-            color={'gray.100'}
+            fontWeight={'bold'}
+            fontSize={'xs'}
+            color={'lightgreen'}
           >
             TEST
           </Text>
         </Box>
         <Image
-          src={PLATFORMS[logo].svg}
-          alt={PLATFORMS[logo].text}
+          src={LOGOS[logo].svg}
+          alt={LOGOS[logo].text}
         />
-        <Box as="span">{PLATFORMS[logo].text}</Box>
+        <Box as="span">{LOGOS[logo].text}</Box>
       </BorderBox>
     </button>
   );

--- a/src/components/molecules/TestSignInButton/index.stories.tsx
+++ b/src/components/molecules/TestSignInButton/index.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta } from '@storybook/react';
+import TestSignInButton from './TestSignInButton';
+
+const meta = {
+  title: 'Resumeme/Components/Molecules/TestSignInButton',
+  component: TestSignInButton,
+  tags: ['autodocs'],
+} satisfies Meta<typeof TestSignInButton>;
+
+export default meta;
+
+export const MenteeSignInButton = () => {
+  return (
+    <TestSignInButton
+      logo="mentee"
+      onClick={() => {}}
+    />
+  );
+};
+
+export const MentorSignInButton = () => {
+  return (
+    <TestSignInButton
+      logo="mentor"
+      onClick={() => {}}
+    />
+  );
+};

--- a/src/components/molecules/TestSignInButton/index.ts
+++ b/src/components/molecules/TestSignInButton/index.ts
@@ -1,0 +1,3 @@
+import TestSignInButton from './TestSignInButton';
+
+export { TestSignInButton };

--- a/src/components/templates/SignInTemplate/SignInTemplate.tsx
+++ b/src/components/templates/SignInTemplate/SignInTemplate.tsx
@@ -1,10 +1,11 @@
 import { ChevronRightIcon } from '@chakra-ui/icons';
-import { Image, Divider, Flex, Heading, Icon, Text } from '@chakra-ui/react';
+import { Image, Divider, Flex, Heading, Icon, Text, Box } from '@chakra-ui/react';
 import { Link } from '@chakra-ui/react';
 import { AiFillGithub } from 'react-icons/ai';
 import { RiNotionFill } from 'react-icons/ri';
 import { BorderBox } from '~/components/atoms/BorderBox';
 import { OAuthSignInButton } from '~/components/molecules/OAuthSignInButton';
+import { TestSignInButton } from '~/components/molecules/TestSignInButton';
 import { assets } from '~/config/assets';
 import CONSTANTS from '~/constants';
 
@@ -40,10 +41,27 @@ const SignInTemplate = () => {
         </Text>
         <Divider borderColor={'gray.300'} />
         <Text color={'gray.700'}>{TEXT.subMessage}</Text>
-        <OAuthSignInButton
-          oAuthPlatform="kakao"
-          onClick={handleKakaoClick}
-        />
+        <Box
+          display={'flex'}
+          gap={4}
+        >
+          <OAuthSignInButton
+            oAuthPlatform="kakao"
+            onClick={handleKakaoClick}
+          />
+          <TestSignInButton
+            logo="mentee"
+            onClick={() => {
+              alert('clicked!');
+            }}
+          />
+          <TestSignInButton
+            logo="mentor"
+            onClick={() => {
+              alert('clicked!');
+            }}
+          />
+        </Box>
         <Link href={'#'}>
           <Text
             display={'flex'}

--- a/src/components/templates/SignInTemplate/SignInTemplate.tsx
+++ b/src/components/templates/SignInTemplate/SignInTemplate.tsx
@@ -7,7 +7,7 @@ import { BorderBox } from '~/components/atoms/BorderBox';
 import { OAuthSignInButton } from '~/components/molecules/OAuthSignInButton';
 import { TestSignInButton } from '~/components/molecules/TestSignInButton';
 import { assets } from '~/config/assets';
-import CONSTANTS from '~/constants';
+// import CONSTANTS from '~/constants';
 
 const TEXT = {
   welcomeMessage: '이력, 써에 가입하고 피드백을 받아보세요.',
@@ -19,7 +19,8 @@ const TEXT = {
 
 const SignInTemplate = () => {
   const handleKakaoClick = () => {
-    window.location.href = CONSTANTS.KAKAO_SIGNIN_URL;
+    alert('현재는 테스트 계정만 로그인할 수 있습니다.');
+    // window.location.href = CONSTANTS.KAKAO_SIGNIN_URL;
   };
 
   return (


### PR DESCRIPTION
## 💻 스크린샷 (선택사항)
<!-- (선택사항) 구현 스크린샷 혹은 움짤, 영상 등을 올려주세요. -->
![image](https://github.com/resumeme/Frontend/assets/74141521/f2e1a0f9-387c-4513-8067-cd0347ad9e55)

## 📃 PR 설명
<!-- 요구사항과 구현 내용을 간략히 설명해주세요. -->
- `TestSiginInButton` 컴포넌트 추가
    (`'src\components\molecules\TestSinginButton'`)
- 로그인 페이지에 테스트 버튼 2종 추가
  - 멘티 로그인 for Test
  - 멘토 로그인 for Test
- 카카오 로그인 비활성화
  - 주석 처리
  - alert 띄우기

## 📃 참고사항
<!-- 부가적인 설명을 통해서 리뷰어들의 이해를 도울만한 내용을 적어주세요. -->

## 🔎 PR포인트 및 궁금한 점
